### PR TITLE
fix/spec -- non_exhaustive enums, testStepId

### DIFF
--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -84,9 +84,9 @@ impl StdoutWriter {
 }
 
 pub struct JsonEmitter {
-    sequence_no: Arc<atomic::AtomicU64>,
     timezone: chrono_tz::Tz,
     writer: WriterType,
+    seqno: Arc<atomic::AtomicU64>,
 }
 
 impl JsonEmitter {
@@ -94,7 +94,7 @@ impl JsonEmitter {
         JsonEmitter {
             timezone,
             writer,
-            sequence_no: Arc::new(atomic::AtomicU64::new(0)),
+            seqno: Arc::new(atomic::AtomicU64::new(0)),
         }
     }
 
@@ -110,8 +110,8 @@ impl JsonEmitter {
     }
 
     fn next_sequence_no(&self) -> u64 {
-        self.sequence_no.fetch_add(1, atomic::Ordering::SeqCst);
-        self.sequence_no.load(atomic::Ordering::SeqCst)
+        self.seqno.fetch_add(1, atomic::Ordering::SeqCst);
+        self.seqno.load(atomic::Ordering::SeqCst)
     }
 
     pub async fn emit(&self, object: &spec::RootArtifact) -> Result<(), WriterError> {

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -98,15 +98,15 @@ impl JsonEmitter {
         }
     }
 
-    fn serialize_artifact(&self, object: &spec::RootArtifact) -> serde_json::Value {
+    fn serialize_artifact(&self, object: &spec::RootImpl) -> serde_json::Value {
         let now = chrono::Local::now();
         let now_tz = now.with_timezone(&self.timezone);
-        let out_artifact = spec::Root {
+        let root = spec::Root {
             artifact: object.clone(),
             timestamp: now_tz,
             seqno: self.next_sequence_no(),
         };
-        serde_json::json!(out_artifact)
+        serde_json::json!(root)
     }
 
     fn next_sequence_no(&self) -> u64 {
@@ -114,7 +114,7 @@ impl JsonEmitter {
         self.seqno.load(atomic::Ordering::SeqCst)
     }
 
-    pub async fn emit(&self, object: &spec::RootArtifact) -> Result<(), WriterError> {
+    pub async fn emit(&self, object: &spec::RootImpl) -> Result<(), WriterError> {
         let serialized = self.serialize_artifact(object);
         match self.writer {
             WriterType::File(ref file) => file.write(&serialized.to_string()).await?,
@@ -132,8 +132,6 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::output as tv;
-    use tv::run::SchemaVersion;
 
     #[tokio::test]
     async fn test_emit_using_buffer_writer() -> Result<()> {
@@ -149,8 +147,11 @@ mod tests {
         let writer = BufferWriter::new(buffer.clone());
         let emitter = JsonEmitter::new(chrono_tz::UTC, WriterType::Buffer(writer));
 
-        let version = SchemaVersion::new();
-        emitter.emit(&version.to_artifact()).await?;
+        emitter
+            .emit(&spec::RootImpl::SchemaVersion(
+                spec::SchemaVersion::default(),
+            ))
+            .await?;
 
         let deserialized = serde_json::from_str::<serde_json::Value>(
             buffer.lock().await.first().ok_or(anyhow!("no outputs"))?,
@@ -180,9 +181,10 @@ mod tests {
         let buffer = Arc::new(Mutex::new(vec![]));
         let writer = BufferWriter::new(buffer.clone());
         let emitter = JsonEmitter::new(chrono_tz::UTC, WriterType::Buffer(writer));
-        let version = SchemaVersion::new();
-        emitter.emit(&version.to_artifact()).await?;
-        emitter.emit(&version.to_artifact()).await?;
+
+        let version = spec::RootImpl::SchemaVersion(spec::SchemaVersion::default());
+        emitter.emit(&version).await?;
+        emitter.emit(&version).await?;
 
         let deserialized = serde_json::from_str::<serde_json::Value>(
             buffer.lock().await.first().ok_or(anyhow!("no outputs"))?,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -10,7 +10,7 @@ mod emitter;
 mod error;
 mod log;
 mod macros;
-mod measurement;
+mod measure;
 mod run;
 mod state;
 mod step;
@@ -25,7 +25,7 @@ pub use dut::*;
 pub use emitter::*;
 pub use error::*;
 pub use log::*;
-pub use measurement::*;
+pub use measure::*;
 pub use run::*;
 pub use step::*;
 

--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -16,7 +16,7 @@ use tokio::sync::Mutex;
 use crate::output as tv;
 use crate::spec;
 use tv::step::TestStep;
-use tv::{config, dut, emitter, error, log, run, state};
+use tv::{config, dut, emitter, error, log, state};
 
 /// The outcome of a TestRun.
 /// It's returned when the scope method of the [`TestRun`] object is used.
@@ -33,10 +33,10 @@ pub struct TestRunOutcome {
 pub struct TestRun {
     name: String,
     version: String,
-    parameters: Map<String, Value>,
+    parameters: Map<String, tv::Value>,
     dut: dut::DutInfo,
     command_line: String,
-    metadata: Option<Map<String, Value>>,
+    metadata: Option<serde_json::Map<String, tv::Value>>,
     state: Arc<Mutex<state::TestState>>,
 }
 
@@ -87,35 +87,28 @@ impl TestRun {
     /// # });
     /// ```
     pub async fn start(self) -> Result<StartedTestRun, emitter::WriterError> {
-        let version = SchemaVersion::new();
+        // TODO: this likely will go into the emitter since it's not the run's job to emit the schema version
         self.state
             .lock()
             .await
             .emitter
-            .emit(&version.to_artifact())
+            .emit(&spec::RootImpl::SchemaVersion(
+                spec::SchemaVersion::default(),
+            ))
             .await?;
 
-        let mut builder = run::TestRunStart::builder(
-            &self.name,
-            &self.version,
-            &self.command_line,
-            &self.parameters,
-            &self.dut,
-        );
+        let start = spec::RootImpl::TestRunArtifact(spec::TestRunArtifact {
+            artifact: spec::TestRunArtifactImpl::TestRunStart(spec::TestRunStart {
+                name: self.name.clone(),
+                version: self.version.clone(),
+                command_line: self.command_line.clone(),
+                parameters: self.parameters.clone(),
+                metadata: self.metadata.clone(),
+                dut_info: self.dut.to_spec(),
+            }),
+        });
 
-        if let Some(m) = &self.metadata {
-            for m in m {
-                builder = builder.add_metadata(m.0, m.1.clone())
-            }
-        }
-
-        let start = builder.build();
-        self.state
-            .lock()
-            .await
-            .emitter
-            .emit(&start.to_artifact())
-            .await?;
+        self.state.lock().await.emitter.emit(&start).await?;
 
         Ok(StartedTestRun::new(self))
     }
@@ -317,14 +310,13 @@ impl StartedTestRun {
         status: spec::TestStatus,
         result: spec::TestResult,
     ) -> Result<(), emitter::WriterError> {
-        let end = run::TestRunEnd::builder()
-            .status(status)
-            .result(result)
-            .build();
+        let end = spec::RootImpl::TestRunArtifact(spec::TestRunArtifact {
+            artifact: spec::TestRunArtifactImpl::TestRunEnd(spec::TestRunEnd { status, result }),
+        });
 
         let emitter = &self.run.state.lock().await.emitter;
 
-        emitter.emit(&end.to_artifact()).await?;
+        emitter.emit(&end).await?;
         Ok(())
     }
 
@@ -360,10 +352,10 @@ impl StartedTestRun {
         let emitter = &self.run.state.lock().await.emitter;
 
         let artifact = spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::Log(log.to_artifact()),
+            artifact: spec::TestRunArtifactImpl::Log(log.to_artifact()),
         };
         emitter
-            .emit(&spec::RootArtifact::TestRunArtifact(artifact))
+            .emit(&spec::RootImpl::TestRunArtifact(artifact))
             .await?;
 
         Ok(())
@@ -396,10 +388,10 @@ impl StartedTestRun {
         let emitter = &self.run.state.lock().await.emitter;
 
         let artifact = spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::Log(log.to_artifact()),
+            artifact: spec::TestRunArtifactImpl::Log(log.to_artifact()),
         };
         emitter
-            .emit(&spec::RootArtifact::TestRunArtifact(artifact))
+            .emit(&spec::RootImpl::TestRunArtifact(artifact))
             .await?;
 
         Ok(())
@@ -428,10 +420,10 @@ impl StartedTestRun {
         let emitter = &self.run.state.lock().await.emitter;
 
         let artifact = spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::Error(error.to_artifact()),
+            artifact: spec::TestRunArtifactImpl::Error(error.to_artifact()),
         };
         emitter
-            .emit(&spec::RootArtifact::TestRunArtifact(artifact))
+            .emit(&spec::RootImpl::TestRunArtifact(artifact))
             .await?;
 
         Ok(())
@@ -465,10 +457,10 @@ impl StartedTestRun {
         let emitter = &self.run.state.lock().await.emitter;
 
         let artifact = spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::Error(error.to_artifact()),
+            artifact: spec::TestRunArtifactImpl::Error(error.to_artifact()),
         };
         emitter
-            .emit(&spec::RootArtifact::TestRunArtifact(artifact))
+            .emit(&spec::RootImpl::TestRunArtifact(artifact))
             .await?;
 
         Ok(())
@@ -505,10 +497,10 @@ impl StartedTestRun {
         let emitter = &self.run.state.lock().await.emitter;
 
         let artifact = spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::Error(error.to_artifact()),
+            artifact: spec::TestRunArtifactImpl::Error(error.to_artifact()),
         };
         emitter
-            .emit(&spec::RootArtifact::TestRunArtifact(artifact))
+            .emit(&spec::RootImpl::TestRunArtifact(artifact))
             .await?;
 
         Ok(())
@@ -517,184 +509,5 @@ impl StartedTestRun {
     pub fn step(&self, name: &str) -> TestStep {
         let step_id = format!("step_{}", self.step_seqno.fetch_add(1, Ordering::AcqRel));
         TestStep::new(&step_id, name, self.run.state.clone())
-    }
-}
-
-pub struct TestRunStart {
-    name: String,
-    version: String,
-    command_line: String,
-    parameters: Map<String, Value>,
-    metadata: Option<Map<String, Value>>,
-    dut_info: dut::DutInfo,
-}
-
-impl TestRunStart {
-    pub fn builder(
-        name: &str,
-        version: &str,
-        command_line: &str,
-        parameters: &Map<String, Value>,
-        dut_info: &dut::DutInfo,
-    ) -> TestRunStartBuilder {
-        TestRunStartBuilder::new(name, version, command_line, parameters, dut_info)
-    }
-
-    pub fn to_artifact(&self) -> spec::RootArtifact {
-        spec::RootArtifact::TestRunArtifact(spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::TestRunStart(spec::TestRunStart {
-                name: self.name.clone(),
-                version: self.version.clone(),
-                command_line: self.command_line.clone(),
-                parameters: self.parameters.clone(),
-                metadata: self.metadata.clone(),
-                dut_info: self.dut_info.to_spec(),
-            }),
-        })
-    }
-}
-
-pub struct TestRunStartBuilder {
-    name: String,
-    version: String,
-    command_line: String,
-    parameters: Map<String, Value>,
-    metadata: Option<Map<String, Value>>,
-    dut_info: dut::DutInfo,
-}
-
-impl TestRunStartBuilder {
-    pub fn new(
-        name: &str,
-        version: &str,
-        command_line: &str,
-        parameters: &Map<String, Value>,
-        dut_info: &dut::DutInfo,
-    ) -> TestRunStartBuilder {
-        TestRunStartBuilder {
-            name: name.to_string(),
-            version: version.to_string(),
-            command_line: command_line.to_string(),
-            parameters: parameters.clone(),
-            metadata: None,
-            dut_info: dut_info.clone(),
-        }
-    }
-
-    pub fn add_metadata(mut self, key: &str, value: Value) -> TestRunStartBuilder {
-        self.metadata = match self.metadata {
-            Some(mut metadata) => {
-                metadata.insert(key.to_string(), value.clone());
-                Some(metadata)
-            }
-            None => {
-                let mut metadata = Map::new();
-                metadata.insert(key.to_string(), value.clone());
-                Some(metadata)
-            }
-        };
-        self
-    }
-
-    pub fn build(self) -> TestRunStart {
-        TestRunStart {
-            name: self.name,
-            version: self.version,
-            command_line: self.command_line,
-            parameters: self.parameters,
-            metadata: self.metadata,
-            dut_info: self.dut_info,
-        }
-    }
-}
-
-pub struct TestRunEnd {
-    status: spec::TestStatus,
-    result: spec::TestResult,
-}
-
-impl TestRunEnd {
-    pub fn builder() -> TestRunEndBuilder {
-        TestRunEndBuilder::new()
-    }
-
-    pub fn to_artifact(&self) -> spec::RootArtifact {
-        spec::RootArtifact::TestRunArtifact(spec::TestRunArtifact {
-            artifact: spec::TestRunArtifactDescendant::TestRunEnd(spec::TestRunEnd {
-                status: self.status.clone(),
-                result: self.result.clone(),
-            }),
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct TestRunEndBuilder {
-    status: spec::TestStatus,
-    result: spec::TestResult,
-}
-
-#[allow(clippy::new_without_default)]
-impl TestRunEndBuilder {
-    pub fn new() -> TestRunEndBuilder {
-        TestRunEndBuilder {
-            status: spec::TestStatus::Complete,
-            result: spec::TestResult::Pass,
-        }
-    }
-    pub fn status(mut self, value: spec::TestStatus) -> TestRunEndBuilder {
-        self.status = value;
-        self
-    }
-
-    pub fn result(mut self, value: spec::TestResult) -> TestRunEndBuilder {
-        self.result = value;
-        self
-    }
-
-    pub fn build(self) -> TestRunEnd {
-        TestRunEnd {
-            status: self.status,
-            result: self.result,
-        }
-    }
-}
-
-// TODO: this likely will go into the emitter since it's not the run's job to emit the schema version
-pub struct SchemaVersion {
-    major: i8,
-    minor: i8,
-}
-
-#[allow(clippy::new_without_default)]
-impl SchemaVersion {
-    pub fn new() -> SchemaVersion {
-        SchemaVersion {
-            major: spec::SPEC_VERSION.0,
-            minor: spec::SPEC_VERSION.1,
-        }
-    }
-
-    pub fn to_artifact(&self) -> spec::RootArtifact {
-        spec::RootArtifact::SchemaVersion(spec::SchemaVersion {
-            major: self.major,
-            minor: self.minor,
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use anyhow::Result;
-
-    use super::*;
-    use crate::spec;
-
-    #[test]
-    fn test_schema_creation_from_builder() -> Result<()> {
-        let version = SchemaVersion::new();
-        assert_eq!(version.major, spec::SPEC_VERSION.0);
-        assert_eq!(version.minor, spec::SPEC_VERSION.1);
-        Ok(())
     }
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -38,70 +38,6 @@ mod rfc3339_format {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq, Clone)]
-pub enum TestRunArtifactDescendant {
-    #[serde(rename = "testRunStart")]
-    TestRunStart(TestRunStart),
-
-    #[serde(rename = "testRunEnd")]
-    TestRunEnd(TestRunEnd),
-
-    #[serde(rename = "log")]
-    Log(Log),
-
-    #[serde(rename = "error")]
-    Error(Error),
-}
-
-#[derive(Debug, Serialize, PartialEq, Clone)]
-pub enum RootArtifact {
-    #[serde(rename = "schemaVersion")]
-    SchemaVersion(SchemaVersion),
-
-    #[serde(rename = "testRunArtifact")]
-    TestRunArtifact(TestRunArtifact),
-
-    #[serde(rename = "testStepArtifact")]
-    TestStepArtifact(TestStepArtifact),
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Serialize, PartialEq, Clone)]
-pub enum TestStepArtifactDescendant {
-    #[serde(rename = "testStepStart")]
-    TestStepStart(TestStepStart),
-
-    #[serde(rename = "testStepEnd")]
-    TestStepEnd(TestStepEnd),
-
-    #[serde(rename = "measurement")]
-    Measurement(Measurement),
-
-    #[serde(rename = "measurementSeriesStart")]
-    MeasurementSeriesStart(MeasurementSeriesStart),
-
-    #[serde(rename = "measurementSeriesEnd")]
-    MeasurementSeriesEnd(MeasurementSeriesEnd),
-
-    #[serde(rename = "measurementSeriesElement")]
-    MeasurementSeriesElement(MeasurementSeriesElement),
-
-    #[serde(rename = "diagnosis")]
-    Diagnosis(Diagnosis),
-
-    #[serde(rename = "log")]
-    Log(Log),
-
-    #[serde(rename = "error")]
-    Error(Error),
-
-    #[serde(rename = "file")]
-    File(File),
-
-    #[serde(rename = "extension")]
-    Extension(Extension),
-}
-
 #[derive(Debug, Serialize, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum ValidatorType {
@@ -241,7 +177,7 @@ pub enum SoftwareType {
 #[derive(Debug, Serialize, Clone)]
 pub struct Root {
     #[serde(flatten)]
-    pub artifact: RootArtifact,
+    pub artifact: RootImpl,
 
     // TODO : manage different timezones
     #[serde(rename = "timestamp")]
@@ -250,6 +186,18 @@ pub struct Root {
 
     #[serde(rename = "sequenceNumber")]
     pub seqno: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Clone)]
+pub enum RootImpl {
+    #[serde(rename = "schemaVersion")]
+    SchemaVersion(SchemaVersion),
+
+    #[serde(rename = "testRunArtifact")]
+    TestRunArtifact(TestRunArtifact),
+
+    #[serde(rename = "testStepArtifact")]
+    TestStepArtifact(TestStepArtifact),
 }
 
 /// Low-level model for the `schemaVersion` spec object.
@@ -267,6 +215,15 @@ pub struct SchemaVersion {
     pub minor: i8,
 }
 
+impl Default for SchemaVersion {
+    fn default() -> Self {
+        SchemaVersion {
+            major: SPEC_VERSION.0,
+            minor: SPEC_VERSION.1,
+        }
+    }
+}
+
 /// Low-level model for the `testRunArtifact` spec object.
 /// Container for the run level artifacts.
 /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#test-run-artifacts
@@ -275,7 +232,22 @@ pub struct SchemaVersion {
 #[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct TestRunArtifact {
     #[serde(flatten)]
-    pub artifact: TestRunArtifactDescendant,
+    pub artifact: TestRunArtifactImpl,
+}
+
+#[derive(Debug, Serialize, PartialEq, Clone)]
+pub enum TestRunArtifactImpl {
+    #[serde(rename = "testRunStart")]
+    TestRunStart(TestRunStart),
+
+    #[serde(rename = "testRunEnd")]
+    TestRunEnd(TestRunEnd),
+
+    #[serde(rename = "log")]
+    Log(Log),
+
+    #[serde(rename = "error")]
+    Error(Error),
 }
 
 /// Low-level model for the `testRunStart` spec object.
@@ -498,7 +470,44 @@ pub struct TestStepArtifact {
     pub id: String,
 
     #[serde(flatten)]
-    pub descendant: TestStepArtifactDescendant,
+    pub artifact: TestStepArtifactImpl,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
+pub enum TestStepArtifactImpl {
+    #[serde(rename = "testStepStart")]
+    TestStepStart(TestStepStart),
+
+    #[serde(rename = "testStepEnd")]
+    TestStepEnd(TestStepEnd),
+
+    #[serde(rename = "measurement")]
+    Measurement(Measurement),
+
+    #[serde(rename = "measurementSeriesStart")]
+    MeasurementSeriesStart(MeasurementSeriesStart),
+
+    #[serde(rename = "measurementSeriesEnd")]
+    MeasurementSeriesEnd(MeasurementSeriesEnd),
+
+    #[serde(rename = "measurementSeriesElement")]
+    MeasurementSeriesElement(MeasurementSeriesElement),
+
+    #[serde(rename = "diagnosis")]
+    Diagnosis(Diagnosis),
+
+    #[serde(rename = "log")]
+    Log(Log),
+
+    #[serde(rename = "error")]
+    Error(Error),
+
+    #[serde(rename = "file")]
+    File(File),
+
+    #[serde(rename = "extension")]
+    Extension(Extension),
 }
 
 /// Low-level model for the `testStepStart` spec object.

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -494,6 +494,9 @@ pub struct SourceLocation {
 /// schema ref: https://github.com/opencomputeproject/ocp-diag-core/testStepArtifact
 #[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct TestStepArtifact {
+    #[serde(rename = "testStepId")]
+    pub id: String,
+
     #[serde(flatten)]
     pub descendant: TestStepArtifactDescendant,
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -103,6 +103,7 @@ pub enum TestStepArtifactDescendant {
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ValidatorType {
     #[serde(rename = "EQUAL")]
     Equal,
@@ -175,6 +176,7 @@ pub enum DiagnosisType {
 /// schema ref: https://github.com/opencomputeproject/ocp-diag-core/testStatus
 #[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(rename = "testStatus")]
+#[non_exhaustive]
 pub enum TestStatus {
     #[serde(rename = "COMPLETE")]
     Complete,
@@ -190,6 +192,7 @@ pub enum TestStatus {
 /// schema ref: https://github.com/opencomputeproject/ocp-diag-core/testRunEnd/$defs/testResult
 #[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(rename = "testResult")]
+#[non_exhaustive]
 pub enum TestResult {
     #[serde(rename = "PASS")]
     Pass,
@@ -198,11 +201,13 @@ pub enum TestResult {
     #[serde(rename = "NOT_APPLICABLE")]
     NotApplicable,
 }
+
 /// Known log severity variants.
 /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#severity
 /// schema url: https://github.com/opencomputeproject/ocp-diag-core/blob/main/json_spec/output/log.json
 /// schema ref: https://github.com/opencomputeproject/ocp-diag-core/log/$defs/severity
 #[derive(Debug, Serialize, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum LogSeverity {
     #[serde(rename = "DEBUG")]
     Debug,

--- a/tests/output/runner.rs
+++ b/tests/output/runner.rs
@@ -498,6 +498,7 @@ async fn test_testrun_step_error_with_details() -> Result<()> {
         json!({
             "sequenceNumber": 4,
             "testStepArtifact": {
+                "testStepId": "step_0",
                 "error": {
                     "message": "Error message",
                     "softwareInfoIds":[{
@@ -579,12 +580,14 @@ async fn test_step_with_measurement() -> Result<()> {
         json_run_default_start(),
         json_step_default_start(),
         json!({
-            "sequenceNumber": 4,
             "testStepArtifact": {
+                "testStepId": "step_0",
                 "measurement": {
-                    "name": "name", "value": 50
+                    "name": "name",
+                    "value": 50
                 }
-            }
+            },
+            "sequenceNumber": 4
         }),
         json_step_complete(5),
         json_run_pass(6),
@@ -601,6 +604,8 @@ async fn test_step_with_measurement() -> Result<()> {
     .await
 }
 
+// TODO: intentionally leaving these tests broken so that it's obvious later that the
+// assert_json_includes was not sufficient; this case is missing `testStepId` field
 #[tokio::test]
 async fn test_step_with_measurement_builder() -> Result<()> {
     let expected = [


### PR DESCRIPTION
- various fixes to spec related constructs (at this point; some still needed later)
  - add `non_exhaustive` to public enums
  - add missing `testStepId` to step artifacts; required refactoring