### PR TITLE
fea/typestate measurement series

### DIFF
--- a/tests/output/runner.rs
+++ b/tests/output/runner.rs
@@ -683,8 +683,7 @@ async fn test_step_with_measurement_series() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name");
-            series.start().await?;
+            let series = step.measurement_series("name").start().await?;
             series.end().await?;
 
             Ok(())
@@ -742,12 +741,10 @@ async fn test_step_with_multiple_measurement_series() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name");
-            series.start().await?;
+            let series = step.measurement_series("name").start().await?;
             series.end().await?;
 
-            let series_2 = step.measurement_series("name");
-            series_2.start().await?;
+            let series_2 = step.measurement_series("name").start().await?;
             series_2.end().await?;
 
             Ok(())
@@ -786,8 +783,9 @@ async fn test_step_with_measurement_series_with_details() -> Result<()> {
     check_output_step(&expected, |step| {
         async {
             let series = step
-                .measurement_series_with_details(MeasurementSeriesStart::new("name", "series_id"));
-            series.start().await?;
+                .measurement_series_with_details(MeasurementSeriesStart::new("name", "series_id"))
+                .start()
+                .await?;
             series.end().await?;
 
             Ok(())
@@ -841,15 +839,17 @@ async fn test_step_with_measurement_series_with_details_and_start_builder() -> R
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series_with_details(
-                MeasurementSeriesStart::builder("name", "series_id")
-                    .add_metadata("key", "value".into())
-                    .add_validator(&Validator::builder(ValidatorType::Equal, 30.into()).build())
-                    .hardware_info(&HardwareInfo::builder("id", "name").build())
-                    .subcomponent(&Subcomponent::builder("name").build())
-                    .build(),
-            );
-            series.start().await?;
+            let series = step
+                .measurement_series_with_details(
+                    MeasurementSeriesStart::builder("name", "series_id")
+                        .add_metadata("key", "value".into())
+                        .add_validator(&Validator::builder(ValidatorType::Equal, 30.into()).build())
+                        .hardware_info(&HardwareInfo::builder("id", "name").build())
+                        .subcomponent(&Subcomponent::builder("name").build())
+                        .build(),
+                )
+                .start()
+                .await?;
             series.end().await?;
 
             Ok(())
@@ -899,8 +899,7 @@ async fn test_step_with_measurement_series_element() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name");
-            series.start().await?;
+            let series = step.measurement_series("name").start().await?;
             series.add_measurement(60.into()).await?;
             series.end().await?;
 
@@ -971,8 +970,7 @@ async fn test_step_with_measurement_series_element_index_no() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name");
-            series.start().await?;
+            let series = step.measurement_series("name").start().await?;
             // add more than one element to check the index increments correctly
             series.add_measurement(60.into()).await?;
             series.add_measurement(70.into()).await?;
@@ -1029,8 +1027,7 @@ async fn test_step_with_measurement_series_element_with_metadata() -> Result<()>
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name");
-            series.start().await?;
+            let series = step.measurement_series("name").start().await?;
             series
                 .add_measurement_with_metadata(60.into(), vec![("key", "value".into())])
                 .await?;
@@ -1106,8 +1103,7 @@ async fn test_step_with_measurement_series_element_with_metadata_index_no() -> R
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name");
-            series.start().await?;
+            let series = step.measurement_series("name").start().await?;
             // add more than one element to check the index increments correctly
             series
                 .add_measurement_with_metadata(60.into(), vec![("key", "value".into())])
@@ -1127,83 +1123,83 @@ async fn test_step_with_measurement_series_element_with_metadata_index_no() -> R
     .await
 }
 
-#[tokio::test]
-async fn test_step_with_measurement_series_scope() -> Result<()> {
-    let expected = [
-        json_schema_version(),
-        json_run_default_start(),
-        json_step_default_start(),
-        json!({
-            "testStepArtifact": {
-                "measurementSeriesStart": {
-                    "measurementSeriesId": "series_0",
-                    "name": "name"
-                }
-            },
-            "sequenceNumber": 3
-        }),
-        json!({
-            "testStepArtifact": {
-                "measurementSeriesElement": {
-                    "index": 0,
-                    "measurementSeriesId": "series_0",
-                    "value": 60
-                }
-            },
-            "sequenceNumber": 4
-        }),
-        json!({
-            "testStepArtifact": {
-                "measurementSeriesElement": {
-                    "index": 1,
-                    "measurementSeriesId": "series_0",
-                    "value": 70
-                }
-            },
-            "sequenceNumber": 5
-        }),
-        json!({
-            "testStepArtifact": {
-                "measurementSeriesElement": {
-                    "index": 2,
-                    "measurementSeriesId": "series_0",
-                    "value": 80
-                }
-            },
-            "sequenceNumber": 6
-        }),
-        json!({
-            "testStepArtifact": {
-                "measurementSeriesEnd": {
-                    "measurementSeriesId": "series_0",
-                    "totalCount": 3
-                }
-            },
-            "sequenceNumber": 7
-        }),
-        json_step_complete(8),
-        json_run_pass(9),
-    ];
+// #[tokio::test]
+// async fn test_step_with_measurement_series_scope() -> Result<()> {
+//     let expected = [
+//         json_schema_version(),
+//         json_run_default_start(),
+//         json_step_default_start(),
+//         json!({
+//             "testStepArtifact": {
+//                 "measurementSeriesStart": {
+//                     "measurementSeriesId": "series_0",
+//                     "name": "name"
+//                 }
+//             },
+//             "sequenceNumber": 3
+//         }),
+//         json!({
+//             "testStepArtifact": {
+//                 "measurementSeriesElement": {
+//                     "index": 0,
+//                     "measurementSeriesId": "series_0",
+//                     "value": 60
+//                 }
+//             },
+//             "sequenceNumber": 4
+//         }),
+//         json!({
+//             "testStepArtifact": {
+//                 "measurementSeriesElement": {
+//                     "index": 1,
+//                     "measurementSeriesId": "series_0",
+//                     "value": 70
+//                 }
+//             },
+//             "sequenceNumber": 5
+//         }),
+//         json!({
+//             "testStepArtifact": {
+//                 "measurementSeriesElement": {
+//                     "index": 2,
+//                     "measurementSeriesId": "series_0",
+//                     "value": 80
+//                 }
+//             },
+//             "sequenceNumber": 6
+//         }),
+//         json!({
+//             "testStepArtifact": {
+//                 "measurementSeriesEnd": {
+//                     "measurementSeriesId": "series_0",
+//                     "totalCount": 3
+//                 }
+//             },
+//             "sequenceNumber": 7
+//         }),
+//         json_step_complete(8),
+//         json_run_pass(9),
+//     ];
 
-    check_output_step(&expected, |step| {
-        async {
-            let series = step.measurement_series("name");
-            series
-                .scope(|s| async {
-                    s.add_measurement(60.into()).await?;
-                    s.add_measurement(70.into()).await?;
-                    s.add_measurement(80.into()).await?;
+//     check_output_step(&expected, |step| {
+//         async {
+//             let series = step.measurement_series("name");
+//             series
+//                 .scope(|s| async {
+//                     s.add_measurement(60.into()).await?;
+//                     s.add_measurement(70.into()).await?;
+//                     s.add_measurement(80.into()).await?;
 
-                    Ok(())
-                })
-                .await?;
+//                     Ok(())
+//                 })
+//                 .await?;
 
-            Ok(())
-        }
-        .boxed()
-    })
-    .await
-}
+//             Ok(())
+//         }
+//         .boxed()
+//     })
+//     .await
+// }
 
 // reasoning: the coverage(off) attribute is experimental in llvm-cov, so because we cannot
 // disable the coverage itself, only run this test when in coverage mode because assert_fs


### PR DESCRIPTION
- add typestate pattern for measurement series (make the api safer to use with compile time guarantees)
- commenting out the `scope` method as in the other typestate commits; in a future PR, these will be gated by a feature