### PR TITLE
fix/cleanup api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,15 +211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,28 +240,6 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
-
-[[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
 
 [[package]]
 name = "difflib"
@@ -535,9 +515,9 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "assert_fs",
+ "async-trait",
  "chrono",
  "chrono-tz",
- "derive_more",
  "futures",
  "predicates",
  "serde",
@@ -545,6 +525,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
+ "unwrap-infallible",
 ]
 
 [[package]]
@@ -904,16 +885,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
+name = "unwrap-infallible"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1.83"
 chrono = "0.4.38"
 chrono-tz = "0.10.0"
-derive_more = { version = "1.0.0", features = ["full"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 thiserror = "1.0.64"
@@ -23,6 +23,7 @@ tokio = { version = "1.40.0", features = [
     "fs",
     "sync",
 ] }
+unwrap-infallible = "0.1.5"
 
 [dev-dependencies]
 anyhow = "1.0.89"

--- a/src/output/config.rs
+++ b/src/output/config.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::output::writer::{self, BufferWriter, FileWriter, StdoutWriter, WriterType};
+use crate::output as tv;
+use crate::output::writer::{BufferWriter, FileWriter, StdoutWriter, WriterType};
 
 /// The configuration repository for the TestRun.
 pub struct Config {
@@ -66,7 +67,7 @@ impl ConfigBuilder {
     pub async fn with_file_output<P: AsRef<Path>>(
         mut self,
         path: P,
-    ) -> Result<Self, writer::WriterError> {
+    ) -> Result<Self, tv::OcptvError> {
         self.writer = Some(WriterType::File(FileWriter::new(path).await?));
         Ok(self)
     }

--- a/src/output/config.rs
+++ b/src/output/config.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::output as tv;
-use crate::output::writer::{BufferWriter, FileWriter, StdoutWriter, WriterType};
+use crate::output::writer::{self, BufferWriter, FileWriter, StdoutWriter, WriterType};
 
 /// The configuration repository for the TestRun.
 pub struct Config {
@@ -70,6 +70,14 @@ impl ConfigBuilder {
     ) -> Result<Self, tv::OcptvError> {
         self.writer = Some(WriterType::File(FileWriter::new(path).await?));
         Ok(self)
+    }
+
+    pub fn with_custom_output(
+        mut self,
+        custom: Box<dyn writer::Writer + Send + Sync + 'static>,
+    ) -> Self {
+        self.writer = Some(WriterType::Custom(custom));
+        self
     }
 
     pub fn build(self) -> Config {

--- a/src/output/macros.rs
+++ b/src/output/macros.rs
@@ -31,7 +31,7 @@
 /// ocptv_error!(test_run, "symptom");
 /// test_run.end(TestStatus::Complete, TestResult::Pass).await?;
 ///
-/// # Ok::<(), WriterError>(())
+/// # Ok::<(), OcptvError>(())
 /// # });
 /// ```
 ///
@@ -47,7 +47,7 @@
 /// ocptv_error!(test_run, "symptom", "Error message");
 /// test_run.end(TestStatus::Complete, TestResult::Pass).await?;
 ///
-/// # Ok::<(), WriterError>(())
+/// # Ok::<(), OcptvError>(())
 /// # });
 /// ```
 #[macro_export]
@@ -94,7 +94,7 @@ macro_rules! ocptv_error {
 /// ocptv_log_debug!(run, "Log message");
 /// run.end(TestStatus::Complete, TestResult::Pass).await?;
 ///
-/// # Ok::<(), WriterError>(())
+/// # Ok::<(), OcptvError>(())
 /// # });
 /// ```
 

--- a/src/output/macros.rs
+++ b/src/output/macros.rs
@@ -53,7 +53,7 @@
 #[macro_export]
 macro_rules! ocptv_error {
     ($runner:expr, $symptom:expr, $msg:expr) => {
-        $runner.error_with_details(
+        $runner.add_error_with_details(
             &$crate::output::Error::builder($symptom)
                 .message($msg)
                 .source(file!(), line!() as i32)
@@ -62,7 +62,7 @@ macro_rules! ocptv_error {
     };
 
     ($runner:expr, $symptom:expr) => {
-        $runner.error_with_details(
+        $runner.add_error_with_details(
             &$crate::output::Error::builder($symptom)
                 .source(file!(), line!() as i32)
                 .build(),
@@ -103,7 +103,7 @@ macro_rules! ocptv_log {
         #[macro_export]
         macro_rules! $name {
             ($artifact:expr, $msg:expr) => {
-                $artifact.log_with_details(
+                $artifact.add_log_with_details(
                     &$crate::output::Log::builder($msg)
                         .severity($crate::output::LogSeverity::$severity)
                         .source(file!(), line!() as i32)

--- a/src/output/measure.rs
+++ b/src/output/measure.rs
@@ -143,7 +143,7 @@ impl StartedMeasurementSeries {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn end(&self) -> Result<(), tv::OcptvError> {
+    pub async fn end(self) -> Result<(), tv::OcptvError> {
         let end = spec::MeasurementSeriesEnd {
             series_id: self.parent.start.series_id.clone(),
             total_count: self.seqno.load(Ordering::Acquire),

--- a/src/output/measure.rs
+++ b/src/output/measure.rs
@@ -52,9 +52,9 @@ impl MeasurementSeries {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     ///
-    /// let series = step.measurement_series("name");
+    /// let series = step.add_measurement_series("name");
     /// series.start().await?;
     ///
     /// # Ok::<(), OcptvError>(())
@@ -87,9 +87,9 @@ impl MeasurementSeries {
     // /// # use ocptv::output::*;
     // ///
     // /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    // /// let step = run.step("step_name").start().await?;
+    // /// let step = run.add_step("step_name").start().await?;
     // ///
-    // /// let series = step.measurement_series("name");
+    // /// let series = step.add_measurement_series("name");
     // /// series.start().await?;
     // /// series.scope(|s| async {
     // ///     s.add_measurement(60.into()).await?;
@@ -135,9 +135,9 @@ impl StartedMeasurementSeries {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     ///
-    /// let series = step.measurement_series("name").start().await?;
+    /// let series = step.add_measurement_series("name").start().await?;
     /// series.end().await?;
     ///
     /// # Ok::<(), OcptvError>(())
@@ -168,9 +168,9 @@ impl StartedMeasurementSeries {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     ///
-    /// let series = step.measurement_series("name").start().await?;
+    /// let series = step.add_measurement_series("name").start().await?;
     /// series.add_measurement(60.into()).await?;
     ///
     /// # Ok::<(), OcptvError>(())
@@ -207,9 +207,9 @@ impl StartedMeasurementSeries {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     ///
-    /// let series = step.measurement_series("name").start().await?;
+    /// let series = step.add_measurement_series("name").start().await?;
     /// series.add_measurement_with_metadata(60.into(), vec![("key", "value".into())]).await?;
     ///
     /// # Ok::<(), OcptvError>(())

--- a/src/output/measure.rs
+++ b/src/output/measure.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::output as tv;
 use crate::spec;
-use tv::{dut, step, writer};
+use tv::{dut, step};
 
 /// The measurement series.
 /// A Measurement Series is a time-series list of measurements.
@@ -57,10 +57,10 @@ impl MeasurementSeries {
     /// let series = step.measurement_series("name");
     /// series.start().await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn start(self) -> Result<StartedMeasurementSeries, writer::WriterError> {
+    pub async fn start(self) -> Result<StartedMeasurementSeries, tv::OcptvError> {
         self.emitter
             .emit(&spec::TestStepArtifactImpl::MeasurementSeriesStart(
                 self.start.to_artifact(),
@@ -98,12 +98,12 @@ impl MeasurementSeries {
     // ///     Ok(())
     // /// }).await?;
     // ///
-    // /// # Ok::<(), WriterError>(())
+    // /// # Ok::<(), OcptvError>(())
     // /// # });
     // /// ```
-    // pub async fn scope<'s, F, R>(&'s self, func: F) -> Result<(), writer::WriterError>
+    // pub async fn scope<'s, F, R>(&'s self, func: F) -> Result<(), tv::OcptvError>
     // where
-    //     R: Future<Output = Result<(), writer::WriterError>>,
+    //     R: Future<Output = Result<(), tv::OcptvError>>,
     //     F: std::ops::FnOnce(&'s MeasurementSeries) -> R,
     // {
     //     self.start().await?;
@@ -140,10 +140,10 @@ impl StartedMeasurementSeries {
     /// let series = step.measurement_series("name").start().await?;
     /// series.end().await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn end(&self) -> Result<(), writer::WriterError> {
+    pub async fn end(&self) -> Result<(), tv::OcptvError> {
         let end = spec::MeasurementSeriesEnd {
             series_id: self.parent.start.series_id.clone(),
             total_count: self.seqno.load(Ordering::Acquire),
@@ -173,10 +173,10 @@ impl StartedMeasurementSeries {
     /// let series = step.measurement_series("name").start().await?;
     /// series.add_measurement(60.into()).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn add_measurement(&self, value: Value) -> Result<(), writer::WriterError> {
+    pub async fn add_measurement(&self, value: Value) -> Result<(), tv::OcptvError> {
         let element = spec::MeasurementSeriesElement {
             index: self.incr_seqno(),
             value: value.clone(),
@@ -212,14 +212,14 @@ impl StartedMeasurementSeries {
     /// let series = step.measurement_series("name").start().await?;
     /// series.add_measurement_with_metadata(60.into(), vec![("key", "value".into())]).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     pub async fn add_measurement_with_metadata(
         &self,
         value: Value,
         metadata: Vec<(&str, Value)>,
-    ) -> Result<(), writer::WriterError> {
+    ) -> Result<(), tv::OcptvError> {
         let element = spec::MeasurementSeriesElement {
             index: self.incr_seqno(),
             value: value.clone(),

--- a/src/output/measure.rs
+++ b/src/output/measure.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::output as tv;
 use crate::spec;
-use tv::{dut, emitter, step};
+use tv::{dut, step, writer};
 
 /// The measurement series.
 /// A Measurement Series is a time-series list of measurements.
@@ -60,7 +60,7 @@ impl MeasurementSeries {
     /// # Ok::<(), WriterError>(())
     /// # });
     /// ```
-    pub async fn start(self) -> Result<StartedMeasurementSeries, emitter::WriterError> {
+    pub async fn start(self) -> Result<StartedMeasurementSeries, writer::WriterError> {
         self.emitter
             .emit(&spec::TestStepArtifactImpl::MeasurementSeriesStart(
                 self.start.to_artifact(),
@@ -101,9 +101,9 @@ impl MeasurementSeries {
     // /// # Ok::<(), WriterError>(())
     // /// # });
     // /// ```
-    // pub async fn scope<'s, F, R>(&'s self, func: F) -> Result<(), emitter::WriterError>
+    // pub async fn scope<'s, F, R>(&'s self, func: F) -> Result<(), writer::WriterError>
     // where
-    //     R: Future<Output = Result<(), emitter::WriterError>>,
+    //     R: Future<Output = Result<(), writer::WriterError>>,
     //     F: std::ops::FnOnce(&'s MeasurementSeries) -> R,
     // {
     //     self.start().await?;
@@ -143,7 +143,7 @@ impl StartedMeasurementSeries {
     /// # Ok::<(), WriterError>(())
     /// # });
     /// ```
-    pub async fn end(&self) -> Result<(), emitter::WriterError> {
+    pub async fn end(&self) -> Result<(), writer::WriterError> {
         let end = spec::MeasurementSeriesEnd {
             series_id: self.parent.start.series_id.clone(),
             total_count: self.seqno.load(Ordering::Acquire),
@@ -176,7 +176,7 @@ impl StartedMeasurementSeries {
     /// # Ok::<(), WriterError>(())
     /// # });
     /// ```
-    pub async fn add_measurement(&self, value: Value) -> Result<(), emitter::WriterError> {
+    pub async fn add_measurement(&self, value: Value) -> Result<(), writer::WriterError> {
         let element = spec::MeasurementSeriesElement {
             index: self.incr_seqno(),
             value: value.clone(),
@@ -219,7 +219,7 @@ impl StartedMeasurementSeries {
         &self,
         value: Value,
         metadata: Vec<(&str, Value)>,
-    ) -> Result<(), emitter::WriterError> {
+    ) -> Result<(), writer::WriterError> {
         let element = spec::MeasurementSeriesElement {
             index: self.incr_seqno(),
             value: value.clone(),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,20 +16,21 @@ mod run;
 mod step;
 mod writer;
 
-pub use crate::spec::LogSeverity;
-pub use crate::spec::TestResult;
-pub use crate::spec::TestStatus;
-pub use crate::spec::ValidatorType;
-pub use crate::spec::SPEC_VERSION;
-pub use config::*;
-pub use dut::*;
-pub use emitter::*;
-pub use error::*;
-pub use log::*;
-pub use measure::*;
-pub use run::*;
-pub use step::*;
-pub use writer::*;
+pub use crate::spec::{LogSeverity, TestResult, TestStatus, ValidatorType, SPEC_VERSION};
+pub use config::{Config, ConfigBuilder, TimestampProvider};
+pub use dut::{
+    DutInfo, DutInfoBuilder, HardwareInfo, HardwareInfoBuilder, PlatformInfo, PlatformInfoBuilder,
+    SoftwareInfo, SoftwareInfoBuilder, Subcomponent, SubcomponentBuilder,
+};
+pub use error::{Error, ErrorBuilder};
+pub use log::{Log, LogBuilder};
+pub use measure::{
+    Measurement, MeasurementBuilder, MeasurementSeries, MeasurementSeriesStart,
+    MeasurementSeriesStartBuilder, StartedMeasurementSeries, Validator, ValidatorBuilder,
+};
+pub use run::{StartedTestRun, TestRun, TestRunBuilder, TestRunOutcome};
+pub use step::{StartedTestStep, TestStep};
+pub use writer::{BufferWriter, FileWriter, StdoutWriter, Writer};
 
 // re-export this as a public type we present
 pub use serde_json::Value;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+#![deny(warnings)]
 
 mod config;
 mod dut;
@@ -33,8 +34,10 @@ pub use writer::*;
 // re-export this as a public type we present
 pub use serde_json::Value;
 
-#[derive(Debug, thiserror::Error, derive_more::Display)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum OcptvError {
-    WriterError(#[from] writer::WriterError),
+    #[error("failed to write to output stream")]
+    IoError(#[from] std::io::Error),
+    // other?
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -13,6 +13,7 @@ mod macros;
 mod measure;
 mod run;
 mod step;
+mod writer;
 
 pub use crate::spec::LogSeverity;
 pub use crate::spec::TestResult;
@@ -27,5 +28,6 @@ pub use log::*;
 pub use measure::*;
 pub use run::*;
 pub use step::*;
+pub use writer::WriterError;
 
 pub use serde_json::Value;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -28,6 +28,13 @@ pub use log::*;
 pub use measure::*;
 pub use run::*;
 pub use step::*;
-pub use writer::WriterError;
+pub use writer::*;
 
+// re-export this as a public type we present
 pub use serde_json::Value;
+
+#[derive(Debug, thiserror::Error, derive_more::Display)]
+#[non_exhaustive]
+pub enum OcptvError {
+    WriterError(#[from] writer::WriterError),
+}

--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -304,7 +304,7 @@ impl StartedTestRun {
     /// # });
     /// ```
     pub async fn end(
-        &self,
+        self,
         status: spec::TestStatus,
         result: spec::TestResult,
     ) -> Result<(), tv::OcptvError> {

--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -128,7 +128,7 @@ impl TestRun {
     // ///
     // /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0");
     // /// run.scope(|r| async {
-    // ///     r.log(LogSeverity::Info, "First message").await?;
+    // ///     r.add_log(LogSeverity::Info, "First message").await?;
     // ///     Ok(TestRunOutcome {
     // ///         status: TestStatus::Complete,
     // ///         result: TestResult::Pass,
@@ -329,7 +329,7 @@ impl StartedTestRun {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// run.log(
+    /// run.add_log(
     ///     LogSeverity::Info,
     ///     "This is a log message with INFO severity",
     /// ).await?;
@@ -338,7 +338,11 @@ impl StartedTestRun {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log(&self, severity: spec::LogSeverity, msg: &str) -> Result<(), tv::OcptvError> {
+    pub async fn add_log(
+        &self,
+        severity: spec::LogSeverity,
+        msg: &str,
+    ) -> Result<(), tv::OcptvError> {
         let log = log::Log::builder(msg).severity(severity).build();
 
         let artifact = spec::TestRunArtifact {
@@ -364,7 +368,7 @@ impl StartedTestRun {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// run.log_with_details(
+    /// run.add_log_with_details(
     ///     &Log::builder("This is a log message with INFO severity")
     ///         .severity(LogSeverity::Info)
     ///         .source("file", 1)
@@ -375,7 +379,7 @@ impl StartedTestRun {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), tv::OcptvError> {
+    pub async fn add_log_with_details(&self, log: &log::Log) -> Result<(), tv::OcptvError> {
         let artifact = spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::Log(log.to_artifact()),
         };
@@ -399,13 +403,13 @@ impl StartedTestRun {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// run.error("symptom").await?;
+    /// run.add_error("symptom").await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error(&self, symptom: &str) -> Result<(), tv::OcptvError> {
+    pub async fn add_error(&self, symptom: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).build();
 
         let artifact = spec::TestRunArtifact {
@@ -432,13 +436,13 @@ impl StartedTestRun {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// run.error_with_msg("symptom", "error messasge").await?;
+    /// run.add_error_with_msg("symptom", "error messasge").await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_msg(&self, symptom: &str, msg: &str) -> Result<(), tv::OcptvError> {
+    pub async fn add_error_with_msg(&self, symptom: &str, msg: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).message(msg).build();
 
         let artifact = spec::TestRunArtifact {
@@ -464,7 +468,7 @@ impl StartedTestRun {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// run.error_with_details(
+    /// run.add_error_with_details(
     ///     &Error::builder("symptom")
     ///         .message("Error message")
     ///         .source("file", 1)
@@ -476,7 +480,7 @@ impl StartedTestRun {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_details(&self, error: &error::Error) -> Result<(), tv::OcptvError> {
+    pub async fn add_error_with_details(&self, error: &error::Error) -> Result<(), tv::OcptvError> {
         let artifact = spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::Error(error.to_artifact()),
         };
@@ -488,7 +492,9 @@ impl StartedTestRun {
         Ok(())
     }
 
-    pub fn step(&self, name: &str) -> TestStep {
+    /// Create a new step for this test run.
+    /// TODO: docs + example
+    pub fn add_step(&self, name: &str) -> TestStep {
         let step_id = format!("step_{}", self.step_seqno.fetch_add(1, Ordering::AcqRel));
         TestStep::new(&step_id, name, Arc::clone(&self.run.emitter))
     }

--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::output as tv;
 use crate::spec;
 use tv::step::TestStep;
-use tv::{config, dut, emitter, error, log};
+use tv::{config, dut, emitter, error, log, writer};
 
 use super::JsonEmitter;
 
@@ -88,7 +88,7 @@ impl TestRun {
     /// # Ok::<(), WriterError>(())
     /// # });
     /// ```
-    pub async fn start(self) -> Result<StartedTestRun, emitter::WriterError> {
+    pub async fn start(self) -> Result<StartedTestRun, writer::WriterError> {
         // TODO: this likely will go into the emitter since it's not the run's job to emit the schema version
         self.emitter
             .emit(&spec::RootImpl::SchemaVersion(
@@ -309,7 +309,7 @@ impl StartedTestRun {
         &self,
         status: spec::TestStatus,
         result: spec::TestResult,
-    ) -> Result<(), emitter::WriterError> {
+    ) -> Result<(), writer::WriterError> {
         let end = spec::RootImpl::TestRunArtifact(spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::TestRunEnd(spec::TestRunEnd { status, result }),
         });
@@ -344,7 +344,7 @@ impl StartedTestRun {
         &self,
         severity: spec::LogSeverity,
         msg: &str,
-    ) -> Result<(), emitter::WriterError> {
+    ) -> Result<(), writer::WriterError> {
         let log = log::Log::builder(msg).severity(severity).build();
 
         let artifact = spec::TestRunArtifact {
@@ -381,7 +381,7 @@ impl StartedTestRun {
     /// # Ok::<(), WriterError>(())
     /// # });
     /// ```
-    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), emitter::WriterError> {
+    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), writer::WriterError> {
         let artifact = spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::Log(log.to_artifact()),
         };
@@ -411,7 +411,7 @@ impl StartedTestRun {
     /// # Ok::<(), WriterError>(())
     /// # });
     /// ```
-    pub async fn error(&self, symptom: &str) -> Result<(), emitter::WriterError> {
+    pub async fn error(&self, symptom: &str) -> Result<(), writer::WriterError> {
         let error = error::Error::builder(symptom).build();
 
         let artifact = spec::TestRunArtifact {
@@ -448,7 +448,7 @@ impl StartedTestRun {
         &self,
         symptom: &str,
         msg: &str,
-    ) -> Result<(), emitter::WriterError> {
+    ) -> Result<(), writer::WriterError> {
         let error = error::Error::builder(symptom).message(msg).build();
 
         let artifact = spec::TestRunArtifact {
@@ -489,7 +489,7 @@ impl StartedTestRun {
     pub async fn error_with_details(
         &self,
         error: &error::Error,
-    ) -> Result<(), emitter::WriterError> {
+    ) -> Result<(), writer::WriterError> {
         let artifact = spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::Error(error.to_artifact()),
         };

--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -17,8 +17,6 @@ use crate::spec;
 use tv::step::TestStep;
 use tv::{config, dut, emitter, error, log};
 
-use super::JsonEmitter;
-
 /// The outcome of a TestRun.
 /// It's returned when the scope method of the [`TestRun`] object is used.
 pub struct TestRunOutcome {
@@ -39,7 +37,7 @@ pub struct TestRun {
     command_line: String,
     metadata: Option<serde_json::Map<String, tv::Value>>,
 
-    emitter: Arc<JsonEmitter>,
+    emitter: Arc<emitter::JsonEmitter>,
 }
 
 impl TestRun {

--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::output as tv;
 use crate::spec;
 use tv::step::TestStep;
-use tv::{config, dut, emitter, error, log, writer};
+use tv::{config, dut, emitter, error, log};
 
 use super::JsonEmitter;
 
@@ -85,10 +85,10 @@ impl TestRun {
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0");
     /// run.start().await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn start(self) -> Result<StartedTestRun, writer::WriterError> {
+    pub async fn start(self) -> Result<StartedTestRun, tv::OcptvError> {
         // TODO: this likely will go into the emitter since it's not the run's job to emit the schema version
         self.emitter
             .emit(&spec::RootImpl::SchemaVersion(
@@ -137,7 +137,7 @@ impl TestRun {
     // ///     })
     // /// }).await?;
     // ///
-    // /// # Ok::<(), WriterError>(())
+    // /// # Ok::<(), OcptvError>(())
     // /// # });
     // /// ```
     // pub async fn scope<F, R>(self, func: F) -> Result<(), emitters::WriterError>
@@ -302,14 +302,14 @@ impl StartedTestRun {
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     pub async fn end(
         &self,
         status: spec::TestStatus,
         result: spec::TestResult,
-    ) -> Result<(), writer::WriterError> {
+    ) -> Result<(), tv::OcptvError> {
         let end = spec::RootImpl::TestRunArtifact(spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::TestRunEnd(spec::TestRunEnd { status, result }),
         });
@@ -337,14 +337,10 @@ impl StartedTestRun {
     /// ).await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log(
-        &self,
-        severity: spec::LogSeverity,
-        msg: &str,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn log(&self, severity: spec::LogSeverity, msg: &str) -> Result<(), tv::OcptvError> {
         let log = log::Log::builder(msg).severity(severity).build();
 
         let artifact = spec::TestRunArtifact {
@@ -378,10 +374,10 @@ impl StartedTestRun {
     /// ).await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), writer::WriterError> {
+    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), tv::OcptvError> {
         let artifact = spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::Log(log.to_artifact()),
         };
@@ -408,10 +404,10 @@ impl StartedTestRun {
     /// run.error("symptom").await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error(&self, symptom: &str) -> Result<(), writer::WriterError> {
+    pub async fn error(&self, symptom: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).build();
 
         let artifact = spec::TestRunArtifact {
@@ -441,14 +437,10 @@ impl StartedTestRun {
     /// run.error_with_msg("symptom", "error messasge").await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_msg(
-        &self,
-        symptom: &str,
-        msg: &str,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn error_with_msg(&self, symptom: &str, msg: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).message(msg).build();
 
         let artifact = spec::TestRunArtifact {
@@ -483,13 +475,10 @@ impl StartedTestRun {
     /// ).await?;
     /// run.end(TestStatus::Complete, TestResult::Pass).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_details(
-        &self,
-        error: &error::Error,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn error_with_details(&self, error: &error::Error) -> Result<(), tv::OcptvError> {
         let artifact = spec::TestRunArtifact {
             artifact: spec::TestRunArtifactImpl::Error(error.to_artifact()),
         };

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -127,7 +127,7 @@ impl StartedTestStep {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn end(&self, status: spec::TestStatus) -> Result<(), tv::OcptvError> {
+    pub async fn end(self, status: spec::TestStatus) -> Result<(), tv::OcptvError> {
         let end = TestStepArtifactImpl::TestStepEnd(spec::TestStepEnd { status });
 
         self.step.emitter.emit(&end).await?;

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 use serde_json::Value;
+use std::io;
 use std::sync::atomic::{self, Ordering};
 use std::sync::Arc;
 
@@ -12,7 +13,7 @@ use crate::output as tv;
 use crate::spec::TestStepStart;
 use crate::spec::{self, TestStepArtifactImpl};
 use tv::measure::MeasurementSeries;
-use tv::{error, log, measure, writer};
+use tv::{error, log, measure};
 
 use super::{JsonEmitter, TimestampProvider};
 
@@ -489,10 +490,7 @@ pub struct StepEmitter {
 }
 
 impl StepEmitter {
-    pub async fn emit(
-        &self,
-        object: &spec::TestStepArtifactImpl,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn emit(&self, object: &spec::TestStepArtifactImpl) -> Result<(), io::Error> {
         let root = spec::RootImpl::TestStepArtifact(spec::TestStepArtifact {
             id: self.step_id.clone(),
             // TODO: can these copies be avoided?

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -13,9 +13,7 @@ use crate::output as tv;
 use crate::spec::TestStepStart;
 use crate::spec::{self, TestStepArtifactImpl};
 use tv::measure::MeasurementSeries;
-use tv::{error, log, measure};
-
-use super::{JsonEmitter, TimestampProvider};
+use tv::{emitter, error, log, measure};
 
 /// A single test step in the scope of a [`TestRun`].
 ///
@@ -27,7 +25,7 @@ pub struct TestStep {
 }
 
 impl TestStep {
-    pub(crate) fn new(id: &str, name: &str, run_emitter: Arc<JsonEmitter>) -> Self {
+    pub(crate) fn new(id: &str, name: &str, run_emitter: Arc<emitter::JsonEmitter>) -> Self {
         TestStep {
             name: name.to_owned(),
             emitter: Arc::new(StepEmitter {
@@ -486,7 +484,7 @@ impl StartedTestStep {
 
 pub struct StepEmitter {
     step_id: String,
-    run_emitter: Arc<JsonEmitter>,
+    run_emitter: Arc<emitter::JsonEmitter>,
 }
 
 impl StepEmitter {
@@ -501,7 +499,8 @@ impl StepEmitter {
         Ok(())
     }
 
-    pub fn timestamp_provider(&self) -> &dyn TimestampProvider {
+    // HACK:
+    pub fn timestamp_provider(&self) -> &dyn tv::config::TimestampProvider {
         &*self.run_emitter.timestamp_provider
     }
 }

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -49,10 +49,10 @@ impl TestStep {
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     /// let step = run.step("step_name").start().await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn start(self) -> Result<StartedTestStep, writer::WriterError> {
+    pub async fn start(self) -> Result<StartedTestStep, tv::OcptvError> {
         self.emitter
             .emit(&TestStepArtifactImpl::TestStepStart(TestStepStart {
                 name: self.name.clone(),
@@ -89,7 +89,7 @@ impl TestStep {
     // ///     Ok(TestStatus::Complete)
     // /// }).await?;
     // ///
-    // /// # Ok::<(), WriterError>(())
+    // /// # Ok::<(), OcptvError>(())
     // /// # });
     // /// ```
     // pub async fn scope<'a, F, R>(&'a self, func: F) -> Result<(), emitters::WriterError>
@@ -125,10 +125,10 @@ impl StartedTestStep {
     /// let step = run.step("step_name").start().await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn end(&self, status: spec::TestStatus) -> Result<(), writer::WriterError> {
+    pub async fn end(&self, status: spec::TestStatus) -> Result<(), tv::OcptvError> {
         let end = TestStepArtifactImpl::TestStepEnd(spec::TestStepEnd { status });
 
         self.step.emitter.emit(&end).await?;
@@ -156,7 +156,7 @@ impl StartedTestStep {
     /// ).await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     /// ## Using macros
@@ -173,14 +173,10 @@ impl StartedTestStep {
     /// ocptv_log_info!(step, "This is a log message with INFO severity").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log(
-        &self,
-        severity: spec::LogSeverity,
-        msg: &str,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn log(&self, severity: spec::LogSeverity, msg: &str) -> Result<(), tv::OcptvError> {
         let log = log::Log::builder(msg).severity(severity).build();
 
         self.step
@@ -213,10 +209,10 @@ impl StartedTestStep {
     /// ).await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), writer::WriterError> {
+    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), tv::OcptvError> {
         self.step
             .emitter
             .emit(&TestStepArtifactImpl::Log(log.to_artifact()))
@@ -242,7 +238,7 @@ impl StartedTestStep {
     /// step.error("symptom").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     ///
@@ -260,10 +256,10 @@ impl StartedTestStep {
     /// ocptv_error!(step, "symptom").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error(&self, symptom: &str) -> Result<(), writer::WriterError> {
+    pub async fn error(&self, symptom: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).build();
 
         self.step
@@ -292,7 +288,7 @@ impl StartedTestStep {
     /// step.error_with_msg("symptom", "error message").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     ///
@@ -310,14 +306,10 @@ impl StartedTestStep {
     /// ocptv_error!(step, "symptom", "error message").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_msg(
-        &self,
-        symptom: &str,
-        msg: &str,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn error_with_msg(&self, symptom: &str, msg: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).message(msg).build();
 
         self.step
@@ -351,13 +343,10 @@ impl StartedTestStep {
     /// ).await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_details(
-        &self,
-        error: &error::Error,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn error_with_details(&self, error: &error::Error) -> Result<(), tv::OcptvError> {
         self.step
             .emitter
             .emit(&TestStepArtifactImpl::Error(error.to_artifact()))
@@ -382,14 +371,10 @@ impl StartedTestStep {
     /// step.add_measurement("name", 50.into()).await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn add_measurement(
-        &self,
-        name: &str,
-        value: Value,
-    ) -> Result<(), writer::WriterError> {
+    pub async fn add_measurement(&self, name: &str, value: Value) -> Result<(), tv::OcptvError> {
         let measurement = measure::Measurement::new(name, value);
 
         self.step
@@ -426,13 +411,13 @@ impl StartedTestStep {
     /// step.add_measurement_with_details(&measurement).await?;
     /// step.end(TestStatus::Complete).await?;
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     pub async fn add_measurement_with_details(
         &self,
         measurement: &measure::Measurement,
-    ) -> Result<(), writer::WriterError> {
+    ) -> Result<(), tv::OcptvError> {
         self.step
             .emitter
             .emit(&spec::TestStepArtifactImpl::Measurement(
@@ -459,7 +444,7 @@ impl StartedTestStep {
     /// let step = run.step("step_name").start().await?;
     /// let series = step.measurement_series("name");
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     pub fn measurement_series(&self, name: &str) -> MeasurementSeries {
@@ -487,7 +472,7 @@ impl StartedTestStep {
     /// let series =
     ///     step.measurement_series_with_details(MeasurementSeriesStart::new("name", "series_id"));
     ///
-    /// # Ok::<(), WriterError>(())
+    /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
     pub fn measurement_series_with_details(

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -46,7 +46,7 @@ impl TestStep {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
@@ -79,9 +79,9 @@ impl TestStep {
     // ///
     // /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     // ///
-    // /// let step = run.step("first step")?;
+    // /// let step = run.add_step("first step")?;
     // /// step.scope(|s| async {
-    // ///     s.log(
+    // ///     s.add_log(
     // ///         LogSeverity::Info,
     // ///         "This is a log message with INFO severity",
     // ///     ).await?;
@@ -121,7 +121,7 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     /// step.end(TestStatus::Complete).await?;
     ///
     /// # Ok::<(), OcptvError>(())
@@ -148,8 +148,8 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
-    /// step.log(
+    /// let step = run.add_step("step_name").start().await?;
+    /// step.add_log(
     ///     LogSeverity::Info,
     ///     "This is a log message with INFO severity",
     /// ).await?;
@@ -168,14 +168,18 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     /// ocptv_log_info!(step, "This is a log message with INFO severity").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log(&self, severity: spec::LogSeverity, msg: &str) -> Result<(), tv::OcptvError> {
+    pub async fn add_log(
+        &self,
+        severity: spec::LogSeverity,
+        msg: &str,
+    ) -> Result<(), tv::OcptvError> {
         let log = log::Log::builder(msg).severity(severity).build();
 
         self.step
@@ -199,8 +203,8 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
-    /// step.log_with_details(
+    /// let step = run.add_step("step_name").start().await?;
+    /// step.add_log_with_details(
     ///     &Log::builder("This is a log message with INFO severity")
     ///         .severity(LogSeverity::Info)
     ///         .source("file", 1)
@@ -211,7 +215,7 @@ impl StartedTestStep {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn log_with_details(&self, log: &log::Log) -> Result<(), tv::OcptvError> {
+    pub async fn add_log_with_details(&self, log: &log::Log) -> Result<(), tv::OcptvError> {
         self.step
             .emitter
             .emit(&TestStepArtifactImpl::Log(log.to_artifact()))
@@ -233,8 +237,8 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
-    /// step.error("symptom").await?;
+    /// let step = run.add_step("step_name").start().await?;
+    /// step.add_error("symptom").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
     /// # Ok::<(), OcptvError>(())
@@ -251,14 +255,14 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     /// ocptv_error!(step, "symptom").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error(&self, symptom: &str) -> Result<(), tv::OcptvError> {
+    pub async fn add_error(&self, symptom: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).build();
 
         self.step
@@ -283,8 +287,8 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
-    /// step.error_with_msg("symptom", "error message").await?;
+    /// let step = run.add_step("step_name").start().await?;
+    /// step.add_error_with_msg("symptom", "error message").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
     /// # Ok::<(), OcptvError>(())
@@ -301,14 +305,14 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     /// ocptv_error!(step, "symptom", "error message").await?;
     /// step.end(TestStatus::Complete).await?;
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_msg(&self, symptom: &str, msg: &str) -> Result<(), tv::OcptvError> {
+    pub async fn add_error_with_msg(&self, symptom: &str, msg: &str) -> Result<(), tv::OcptvError> {
         let error = error::Error::builder(symptom).message(msg).build();
 
         self.step
@@ -332,8 +336,8 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
-    /// step.error_with_details(
+    /// let step = run.add_step("step_name").start().await?;
+    /// step.add_error_with_details(
     ///     &Error::builder("symptom")
     ///         .message("Error message")
     ///         .source("file", 1)
@@ -345,7 +349,7 @@ impl StartedTestStep {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn error_with_details(&self, error: &error::Error) -> Result<(), tv::OcptvError> {
+    pub async fn add_error_with_details(&self, error: &error::Error) -> Result<(), tv::OcptvError> {
         self.step
             .emitter
             .emit(&TestStepArtifactImpl::Error(error.to_artifact()))
@@ -366,7 +370,7 @@ impl StartedTestStep {
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
     ///
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     /// step.add_measurement("name", 50.into()).await?;
     /// step.end(TestStatus::Complete).await?;
     ///
@@ -399,7 +403,7 @@ impl StartedTestStep {
     ///
     /// let hwinfo = HardwareInfo::builder("id", "fan").build();
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     ///
     /// let measurement = Measurement::builder("name", 5000.into())
     ///     .hardware_info(&hwinfo)
@@ -427,7 +431,7 @@ impl StartedTestStep {
         Ok(())
     }
 
-    /// Starts a Measurement Series (a time-series list of measurements).
+    /// Create a Measurement Series (a time-series list of measurements).
     /// This method accepts a [`std::string::String`] as series ID and
     /// a [`std::string::String`] as series name.
     ///
@@ -440,13 +444,13 @@ impl StartedTestStep {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
-    /// let series = step.measurement_series("name");
+    /// let step = run.add_step("step_name").start().await?;
+    /// let series = step.add_measurement_series("name");
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub fn measurement_series(&self, name: &str) -> MeasurementSeries {
+    pub fn add_measurement_series(&self, name: &str) -> MeasurementSeries {
         let series_id: String = format!(
             "series_{}",
             self.measurement_id_seqno.fetch_add(1, Ordering::AcqRel)
@@ -455,7 +459,7 @@ impl StartedTestStep {
         MeasurementSeries::new(&series_id, name, Arc::clone(&self.step.emitter))
     }
 
-    /// Starts a Measurement Series (a time-series list of measurements).
+    /// Create a Measurement Series (a time-series list of measurements).
     /// This method accepts a [`objects::MeasurementSeriesStart`] object.
     ///
     /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#measurementseriesstart
@@ -467,14 +471,14 @@ impl StartedTestStep {
     /// # use ocptv::output::*;
     ///
     /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    /// let step = run.step("step_name").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
     /// let series =
-    ///     step.measurement_series_with_details(MeasurementSeriesStart::new("name", "series_id"));
+    ///     step.add_measurement_series_with_details(MeasurementSeriesStart::new("name", "series_id"));
     ///
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub fn measurement_series_with_details(
+    pub fn add_measurement_series_with_details(
         &self,
         start: measure::MeasurementSeriesStart,
     ) -> MeasurementSeries {

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -1,0 +1,81 @@
+// (c) Meta Platforms, Inc. and affiliates.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use std::io::{self, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+#[derive(Debug, thiserror::Error, derive_more::Display)]
+#[non_exhaustive]
+pub enum WriterError {
+    IoError(#[from] io::Error),
+}
+
+pub(crate) enum WriterType {
+    Stdout(StdoutWriter),
+    File(FileWriter),
+    Buffer(BufferWriter),
+}
+
+pub struct FileWriter {
+    file: Arc<Mutex<fs::File>>,
+}
+
+impl FileWriter {
+    pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self, WriterError> {
+        let file = fs::File::create(path).await.map_err(WriterError::IoError)?;
+        Ok(FileWriter {
+            file: Arc::new(Mutex::new(file)),
+        })
+    }
+
+    pub async fn write(&self, s: &str) -> Result<(), WriterError> {
+        let mut handle = self.file.lock().await;
+
+        let mut buf = Vec::<u8>::new();
+        writeln!(buf, "{}", s)?;
+
+        handle.write_all(&buf).await.map_err(WriterError::IoError)?;
+        handle.flush().await.map_err(WriterError::IoError)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct BufferWriter {
+    buffer: Arc<Mutex<Vec<String>>>,
+}
+
+impl BufferWriter {
+    pub fn new(buffer: Arc<Mutex<Vec<String>>>) -> Self {
+        Self { buffer }
+    }
+
+    pub async fn write(&self, s: &str) -> Result<(), WriterError> {
+        self.buffer.lock().await.push(s.to_string());
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StdoutWriter {}
+
+#[allow(clippy::new_without_default)]
+impl StdoutWriter {
+    pub fn new() -> Self {
+        StdoutWriter {}
+    }
+
+    pub async fn write(&self, s: &str) -> Result<(), WriterError> {
+        println!("{}", s);
+        Ok(())
+    }
+}

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -4,24 +4,28 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use std::convert::Infallible;
 use std::io::{self, Write};
 use std::path::Path;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
-#[derive(Debug, thiserror::Error, derive_more::Display)]
-#[non_exhaustive]
-pub enum WriterError {
-    IoError(#[from] io::Error),
+#[async_trait]
+pub trait Writer {
+    async fn write(&self, s: &str) -> Result<(), io::Error>;
 }
 
-pub(crate) enum WriterType {
+pub enum WriterType {
+    // optimization: static dispatch for these known types
     Stdout(StdoutWriter),
     File(FileWriter),
     Buffer(BufferWriter),
+
+    Custom(Box<dyn Writer + Send + Sync + 'static>),
 }
 
 pub struct FileWriter {
@@ -29,21 +33,21 @@ pub struct FileWriter {
 }
 
 impl FileWriter {
-    pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self, WriterError> {
-        let file = fs::File::create(path).await.map_err(WriterError::IoError)?;
+    pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
+        let file = fs::File::create(path).await?;
         Ok(FileWriter {
             file: Arc::new(Mutex::new(file)),
         })
     }
 
-    pub async fn write(&self, s: &str) -> Result<(), WriterError> {
+    pub async fn write(&self, s: &str) -> Result<(), io::Error> {
         let mut handle = self.file.lock().await;
 
         let mut buf = Vec::<u8>::new();
         writeln!(buf, "{}", s)?;
 
-        handle.write_all(&buf).await.map_err(WriterError::IoError)?;
-        handle.flush().await.map_err(WriterError::IoError)?;
+        handle.write_all(&buf).await?;
+        handle.flush().await?;
 
         Ok(())
     }
@@ -59,7 +63,7 @@ impl BufferWriter {
         Self { buffer }
     }
 
-    pub async fn write(&self, s: &str) -> Result<(), WriterError> {
+    pub async fn write(&self, s: &str) -> Result<(), Infallible> {
         self.buffer.lock().await.push(s.to_string());
         Ok(())
     }
@@ -74,8 +78,46 @@ impl StdoutWriter {
         StdoutWriter {}
     }
 
-    pub async fn write(&self, s: &str) -> Result<(), WriterError> {
+    pub async fn write(&self, s: &str) -> Result<(), Infallible> {
         println!("{}", s);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::*;
+    use anyhow::Result;
+
+    struct ErrorWriter {}
+
+    #[async_trait]
+    impl Writer for ErrorWriter {
+        async fn write(&self, _s: &str) -> Result<(), io::Error> {
+            Err(io::Error::other("err"))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ocptv_error_has_public_source() -> Result<()> {
+        let dut = DutInfo::builder("dut_id").build();
+        let run_builder = TestRun::builder("run_name", &dut, "1.0").config(
+            Config::builder()
+                .with_custom_output(Box::new(ErrorWriter {}))
+                .build(),
+        );
+
+        let actual = run_builder.build().start().await;
+        assert!(actual.is_err());
+
+        match &actual {
+            Err(OcptvError::IoError(ioe)) => {
+                assert_eq!(ioe.kind(), io::ErrorKind::Other);
+            }
+            _ => panic!("unknown error"),
+        }
+
         Ok(())
     }
 }

--- a/tests/output/macros.rs
+++ b/tests/output/macros.rs
@@ -78,7 +78,7 @@ where
     F: FnOnce(StartedTestStep) -> R,
 {
     let actual = check_output::<_, _, 4>(expected, |run| async move {
-        let step = run.step("step_name").start().await?;
+        let step = run.add_step("step_name").start().await?;
 
         func(step).await?;
         Ok(())

--- a/tests/output/runner.rs
+++ b/tests/output/runner.rs
@@ -156,7 +156,7 @@ where
     check_output(expected, |run_builder| async {
         let run = run_builder.build().start().await?;
 
-        let step = run.step("first step").start().await?;
+        let step = run.add_step("first step").start().await?;
         test_fn(&step).await?;
         step.end(TestStatus::Complete).await?;
 
@@ -198,7 +198,7 @@ async fn test_testrun_with_log() -> Result<()> {
 
     check_output_run(&expected, |run| {
         async {
-            run.log(
+            run.add_log(
                 LogSeverity::Info,
                 "This is a log message with INFO severity",
             )
@@ -233,7 +233,7 @@ async fn test_testrun_with_log_with_details() -> Result<()> {
 
     check_output_run(&expected, |run| {
         async {
-            run.log_with_details(
+            run.add_log_with_details(
                 &Log::builder("This is a log message with INFO severity")
                     .severity(LogSeverity::Info)
                     .source("file", 1)
@@ -264,7 +264,7 @@ async fn test_testrun_with_error() -> Result<()> {
     ];
 
     check_output_run(&expected, |run| {
-        async { run.error("symptom").await }.boxed()
+        async { run.add_error("symptom").await }.boxed()
     })
     .await
 }
@@ -288,7 +288,7 @@ async fn test_testrun_with_error_with_message() -> Result<()> {
     ];
 
     check_output_run(&expected, |run| {
-        async { run.error_with_msg("symptom", "Error message").await }.boxed()
+        async { run.add_error_with_msg("symptom", "Error message").await }.boxed()
     })
     .await
 }
@@ -321,7 +321,7 @@ async fn test_testrun_with_error_with_details() -> Result<()> {
 
     check_output_run(&expected, |run| {
         async {
-            run.error_with_details(
+            run.add_error_with_details(
                 &Error::builder("symptom")
                     .message("Error message")
                     .source("file", 1)
@@ -356,7 +356,7 @@ async fn test_testrun_with_error_with_details() -> Result<()> {
 //         let run = run_builder.build();
 
 //         run.scope(|r| async {
-//             r.log(LogSeverity::Info, "First message").await?;
+//             r.add_log(LogSeverity::Info, "First message").await?;
 //             Ok(TestRunOutcome {
 //                 status: TestStatus::Complete,
 //                 result: TestResult::Pass,
@@ -405,7 +405,7 @@ async fn test_testrun_step_log() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            step.log(
+            step.add_log(
                 LogSeverity::Info,
                 "This is a log message with INFO severity",
             )
@@ -445,7 +445,7 @@ async fn test_testrun_step_log_with_details() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            step.log_with_details(
+            step.add_log_with_details(
                 &Log::builder("This is a log message with INFO severity")
                     .severity(LogSeverity::Info)
                     .source("file", 1)
@@ -482,7 +482,7 @@ async fn test_testrun_step_error() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            step.error("symptom").await?;
+            step.add_error("symptom").await?;
 
             Ok(())
         }
@@ -514,7 +514,7 @@ async fn test_testrun_step_error_with_message() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            step.error_with_msg("symptom", "Error message").await?;
+            step.add_error_with_msg("symptom", "Error message").await?;
 
             Ok(())
         }
@@ -554,7 +554,7 @@ async fn test_testrun_step_error_with_details() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            step.error_with_details(
+            step.add_error_with_details(
                 &Error::builder("symptom")
                     .message("Error message")
                     .source("file", 1)
@@ -594,7 +594,7 @@ async fn test_testrun_step_error_with_details() -> Result<()> {
 //             run.step("first step")
 //                 .start()
 //                 .scope(|s| async {
-//                     s.log(
+//                     s.add_log(
 //                         LogSeverity::Info,
 //                         "This is a log message with INFO severity",
 //                     )
@@ -723,7 +723,7 @@ async fn test_step_with_measurement_series() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name").start().await?;
+            let series = step.add_measurement_series("name").start().await?;
             series.end().await?;
 
             Ok(())
@@ -789,10 +789,10 @@ async fn test_step_with_multiple_measurement_series() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name").start().await?;
+            let series = step.add_measurement_series("name").start().await?;
             series.end().await?;
 
-            let series_2 = step.measurement_series("name").start().await?;
+            let series_2 = step.add_measurement_series("name").start().await?;
             series_2.end().await?;
 
             Ok(())
@@ -836,7 +836,10 @@ async fn test_step_with_measurement_series_with_details() -> Result<()> {
     check_output_step(&expected, |step| {
         async {
             let series = step
-                .measurement_series_with_details(MeasurementSeriesStart::new("name", "series_id"))
+                .add_measurement_series_with_details(MeasurementSeriesStart::new(
+                    "name",
+                    "series_id",
+                ))
                 .start()
                 .await?;
             series.end().await?;
@@ -897,7 +900,7 @@ async fn test_step_with_measurement_series_with_details_and_start_builder() -> R
     check_output_step(&expected, |step| {
         async {
             let series = step
-                .measurement_series_with_details(
+                .add_measurement_series_with_details(
                     MeasurementSeriesStart::builder("name", "series_id")
                         .add_metadata("key", "value".into())
                         .add_validator(&Validator::builder(ValidatorType::Equal, 30.into()).build())
@@ -963,7 +966,7 @@ async fn test_step_with_measurement_series_element() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name").start().await?;
+            let series = step.add_measurement_series("name").start().await?;
             series.add_measurement(60.into()).await?;
             series.end().await?;
 
@@ -1047,7 +1050,7 @@ async fn test_step_with_measurement_series_element_index_no() -> Result<()> {
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name").start().await?;
+            let series = step.add_measurement_series("name").start().await?;
             // add more than one element to check the index increments correctly
             series.add_measurement(60.into()).await?;
             series.add_measurement(70.into()).await?;
@@ -1111,7 +1114,7 @@ async fn test_step_with_measurement_series_element_with_metadata() -> Result<()>
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name").start().await?;
+            let series = step.add_measurement_series("name").start().await?;
             series
                 .add_measurement_with_metadata(60.into(), vec![("key", "value".into())])
                 .await?;
@@ -1200,7 +1203,7 @@ async fn test_step_with_measurement_series_element_with_metadata_index_no() -> R
 
     check_output_step(&expected, |step| {
         async {
-            let series = step.measurement_series("name").start().await?;
+            let series = step.add_measurement_series("name").start().await?;
             // add more than one element to check the index increments correctly
             series
                 .add_measurement_with_metadata(60.into(), vec![("key", "value".into())])
@@ -1280,7 +1283,7 @@ async fn test_step_with_measurement_series_element_with_metadata_index_no() -> R
 
 //     check_output_step(&expected, |step| {
 //         async {
-//             let series = step.measurement_series("name");
+//             let series = step.add_measurement_series("name");
 //             series
 //                 .scope(|s| async {
 //                     s.add_measurement(60.into()).await?;
@@ -1338,7 +1341,7 @@ async fn test_config_builder_with_file() -> Result<()> {
         .start()
         .await?;
 
-    run.error_with_msg("symptom", "Error message").await?;
+    run.add_error_with_msg("symptom", "Error message").await?;
 
     run.end(TestStatus::Complete, TestResult::Pass).await?;
 

--- a/tests/output/runner.rs
+++ b/tests/output/runner.rs
@@ -135,7 +135,7 @@ where
 
 async fn check_output_run<F>(expected: &[serde_json::Value], test_fn: F) -> Result<()>
 where
-    F: for<'a> FnOnce(&'a StartedTestRun) -> BoxFuture<'a, Result<(), tv::WriterError>> + Send,
+    F: for<'a> FnOnce(&'a StartedTestRun) -> BoxFuture<'a, Result<(), tv::OcptvError>> + Send,
 {
     check_output(expected, |run_builder| async {
         let run = run_builder.build();
@@ -151,7 +151,7 @@ where
 
 async fn check_output_step<F>(expected: &[serde_json::Value], test_fn: F) -> Result<()>
 where
-    F: for<'a> FnOnce(&'a StartedTestStep) -> BoxFuture<'a, Result<(), tv::WriterError>>,
+    F: for<'a> FnOnce(&'a StartedTestStep) -> BoxFuture<'a, Result<(), tv::OcptvError>>,
 {
     check_output(expected, |run_builder| async {
         let run = run_builder.build().start().await?;


### PR DESCRIPTION
- refactor crate error type
  - add a single error type for most of the api
- cleanup WriterError; custom writer type
  - remove WriterError because it'll always be a type of io::Error
  - add WriterType::Custom so that we can write a test checking an actual
  error return from an api call (missing before this commit)
- explicitly present public crate api
- end methods should consume self
  - this change disallows usage of contextual objects after emitting their
  end artifact, at compile time
- make create api methods naming consistent
  - some methods had a verb, some didnt; add a verb to all the public api
  methods for consistency