### PR TITLE
fix/cleanup impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +525,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "futures",
+ "maplit",
  "predicates",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 async-trait = "0.1.83"
 chrono = "0.4.38"
 chrono-tz = "0.10.0"
+maplit = "1.0.2"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 thiserror = "1.0.64"

--- a/src/output/config.rs
+++ b/src/output/config.rs
@@ -106,6 +106,12 @@ impl TimestampProvider for ConfiguredTzProvider {
 
 pub struct NullTimestampProvider {}
 
+impl NullTimestampProvider {
+    // warn: linter is wrong here, this is used in a serde_json::json! block
+    #[allow(dead_code)]
+    pub const FORMATTED: &str = "1970-01-01T00:00:00.000Z";
+}
+
 impl TimestampProvider for NullTimestampProvider {
     fn now(&self) -> chrono::DateTime<chrono_tz::Tz> {
         chrono::DateTime::from_timestamp_nanos(0).with_timezone(&chrono_tz::UTC)

--- a/src/output/config.rs
+++ b/src/output/config.rs
@@ -14,6 +14,7 @@ use crate::output::writer::{self, BufferWriter, FileWriter, StdoutWriter, Writer
 
 /// The configuration repository for the TestRun.
 pub struct Config {
+    // All fields are readable for any impl inside the crate.
     pub(crate) timestamp_provider: Box<dyn TimestampProvider + Send + Sync + 'static>,
     pub(crate) writer: WriterType,
 }
@@ -46,6 +47,7 @@ impl ConfigBuilder {
         }
     }
 
+    // TODO: docs for all these
     pub fn timezone(mut self, timezone: chrono_tz::Tz) -> Self {
         self.timestamp_provider = Box::new(ConfiguredTzProvider { tz: timezone });
         self
@@ -101,19 +103,5 @@ struct ConfiguredTzProvider {
 impl TimestampProvider for ConfiguredTzProvider {
     fn now(&self) -> chrono::DateTime<chrono_tz::Tz> {
         chrono::Local::now().with_timezone(&self.tz)
-    }
-}
-
-pub struct NullTimestampProvider {}
-
-impl NullTimestampProvider {
-    // warn: linter is wrong here, this is used in a serde_json::json! block
-    #[allow(dead_code)]
-    pub const FORMATTED: &str = "1970-01-01T00:00:00.000Z";
-}
-
-impl TimestampProvider for NullTimestampProvider {
-    fn now(&self) -> chrono::DateTime<chrono_tz::Tz> {
-        chrono::DateTime::from_timestamp_nanos(0).with_timezone(&chrono_tz::UTC)
     }
 }

--- a/src/output/dut.rs
+++ b/src/output/dut.rs
@@ -4,6 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use maplit::{btreemap, convert_args};
+use std::collections::BTreeMap;
+
+use crate::output as tv;
 use crate::spec;
 
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -13,7 +17,7 @@ pub struct DutInfo {
     platform_infos: Option<Vec<PlatformInfo>>,
     software_infos: Option<Vec<SoftwareInfo>>,
     hardware_infos: Option<Vec<HardwareInfo>>,
-    metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 impl DutInfo {
@@ -52,7 +56,7 @@ pub struct DutInfoBuilder {
     platform_infos: Option<Vec<PlatformInfo>>,
     software_infos: Option<Vec<SoftwareInfo>>,
     hardware_infos: Option<Vec<HardwareInfo>>,
-    metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 impl DutInfoBuilder {
@@ -104,17 +108,15 @@ impl DutInfoBuilder {
         self
     }
 
-    pub fn add_metadata(mut self, key: &str, value: serde_json::Value) -> DutInfoBuilder {
+    pub fn add_metadata(mut self, key: &str, value: tv::Value) -> DutInfoBuilder {
         self.metadata = match self.metadata {
             Some(mut metadata) => {
                 metadata.insert(key.to_string(), value.clone());
                 Some(metadata)
             }
-            None => {
-                let mut metadata = serde_json::Map::new();
-                metadata.insert(key.to_string(), value.clone());
-                Some(metadata)
-            }
+            None => Some(convert_args!(btreemap!(
+                key => value
+            ))),
         };
         self
     }

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -66,7 +66,7 @@ impl JsonEmitter {
 #[cfg(test)]
 mod tests {
     use anyhow::{anyhow, Result};
-    use assert_json_diff::assert_json_include;
+    use assert_json_diff::assert_json_eq;
     use serde_json::json;
     use tokio::sync::Mutex;
 
@@ -79,7 +79,8 @@ mod tests {
                 "major": spec::SPEC_VERSION.0,
                 "minor": spec::SPEC_VERSION.1,
             },
-            "sequenceNumber": 0
+            "sequenceNumber": 0,
+            "timestamp": config::NullTimestampProvider::FORMATTED,
         });
 
         let buffer = Arc::new(Mutex::new(vec![]));
@@ -98,7 +99,7 @@ mod tests {
         let deserialized = serde_json::from_str::<serde_json::Value>(
             buffer.lock().await.first().ok_or(anyhow!("no outputs"))?,
         )?;
-        assert_json_include!(actual: deserialized, expected: expected);
+        assert_json_eq!(deserialized, expected);
 
         Ok(())
     }
@@ -110,14 +111,16 @@ mod tests {
                 "major": spec::SPEC_VERSION.0,
                 "minor": spec::SPEC_VERSION.1,
             },
-            "sequenceNumber": 0
+            "sequenceNumber": 0,
+            "timestamp": config::NullTimestampProvider::FORMATTED,
         });
         let expected_2 = json!({
             "schemaVersion": {
                 "major": spec::SPEC_VERSION.0,
                 "minor": spec::SPEC_VERSION.1,
             },
-            "sequenceNumber": 1
+            "sequenceNumber": 1,
+            "timestamp": config::NullTimestampProvider::FORMATTED,
         });
 
         let buffer = Arc::new(Mutex::new(vec![]));
@@ -134,12 +137,12 @@ mod tests {
         let deserialized = serde_json::from_str::<serde_json::Value>(
             buffer.lock().await.first().ok_or(anyhow!("no outputs"))?,
         )?;
-        assert_json_include!(actual: deserialized, expected: expected_1);
+        assert_json_eq!(deserialized, expected_1);
 
         let deserialized = serde_json::from_str::<serde_json::Value>(
             buffer.lock().await.get(1).ok_or(anyhow!("no outputs"))?,
         )?;
-        assert_json_include!(actual: deserialized, expected: expected_2);
+        assert_json_eq!(deserialized, expected_2);
 
         Ok(())
     }

--- a/src/output/error.rs
+++ b/src/output/error.rs
@@ -83,6 +83,7 @@ impl ErrorBuilder {
 mod tests {
     use anyhow::Result;
     use assert_json_diff::assert_json_eq;
+    use serde_json::json;
 
     use super::*;
     use crate::output as tv;
@@ -135,7 +136,7 @@ mod tests {
 
     #[test]
     fn test_error() -> Result<()> {
-        let expected_run = serde_json::json!({
+        let expected_run = json!({
             "message": "message",
             "softwareInfoIds": [
                 {
@@ -153,7 +154,7 @@ mod tests {
             },
             "symptom": "symptom"
         });
-        let expected_step = serde_json::json!({
+        let expected_step = json!({
             "message": "message",
             "softwareInfoIds": [
                 {
@@ -178,11 +179,11 @@ mod tests {
             .build();
 
         let spec_error = error.to_artifact();
-        let actual = serde_json::json!(spec_error);
+        let actual = json!(spec_error);
         assert_json_eq!(actual, expected_run);
 
         let spec_error = error.to_artifact();
-        let actual = serde_json::json!(spec_error);
+        let actual = json!(spec_error);
         assert_json_eq!(actual, expected_step);
 
         Ok(())

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -40,5 +40,7 @@ pub use serde_json::Value;
 pub enum OcptvError {
     #[error("failed to write to output stream")]
     IoError(#[from] std::io::Error),
-    // other?
+
+    #[error("failed to format input object")]
+    Format(Box<dyn std::error::Error + Send + Sync + 'static>), // opaque type so we don't leak impl
 }

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use serde_json::Value;
 use std::io;
 use std::sync::atomic::{self, Ordering};
 use std::sync::Arc;
@@ -377,7 +376,11 @@ impl StartedTestStep {
     /// # Ok::<(), OcptvError>(())
     /// # });
     /// ```
-    pub async fn add_measurement(&self, name: &str, value: Value) -> Result<(), tv::OcptvError> {
+    pub async fn add_measurement(
+        &self,
+        name: &str,
+        value: tv::Value,
+    ) -> Result<(), tv::OcptvError> {
         let measurement = measure::Measurement::new(name, value);
 
         self.step

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -81,19 +81,6 @@ pub enum SubcomponentType {
     Connector,
 }
 
-// TODO: this should be better typed
-#[derive(Debug, Serialize, PartialEq, Clone)]
-pub enum ExtensionContentType {
-    #[serde(rename = "float")]
-    Float(f64),
-    #[serde(rename = "int")]
-    Int(i64),
-    #[serde(rename = "bool")]
-    Bool(bool),
-    #[serde(rename = "str")]
-    Str(String),
-}
-
 /// Outcome of a diagnosis operation.
 /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#diagnosistype
 /// schema url: https://github.com/opencomputeproject/ocp-diag-core/blob/main/json_spec/output/diagnosis.json
@@ -793,8 +780,10 @@ pub struct Extension {
     #[serde(rename = "name")]
     pub name: String,
 
+    // note: have to use a json specific here; alternative is to propagate up an E: Serialize,
+    // which polutes all of the types. Trait Serialize is also not object safe.
     #[serde(rename = "content")]
-    pub content: ExtensionContentType,
+    pub content: serde_json::Value,
 }
 
 #[cfg(test)]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -4,11 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use std::collections::BTreeMap;
+
 use chrono::DateTime;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::Map;
-use serde_json::Value;
+
+use crate::output as tv;
 
 pub const SPEC_VERSION: (i8, i8) = (2, 0);
 
@@ -268,14 +270,14 @@ pub struct TestRunStart {
     pub command_line: String,
 
     #[serde(rename = "parameters")]
-    pub parameters: Map<String, Value>,
+    pub parameters: BTreeMap<String, tv::Value>,
 
     #[serde(rename = "dutInfo")]
     pub dut_info: DutInfo,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `dutInfo` spec object.
@@ -307,7 +309,7 @@ pub struct DutInfo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `platformInfo` spec object.
@@ -570,7 +572,7 @@ pub struct Measurement {
     pub name: String,
 
     #[serde(rename = "value")]
-    pub value: Value,
+    pub value: tv::Value,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "unit")]
@@ -590,7 +592,7 @@ pub struct Measurement {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `validator` spec object.
@@ -609,11 +611,11 @@ pub struct Validator {
     pub validator_type: ValidatorType,
 
     #[serde(rename = "value")]
-    pub value: Value,
+    pub value: tv::Value,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `subcomponent` spec object.
@@ -676,7 +678,7 @@ pub struct MeasurementSeriesStart {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `measurementSeriesEnd` spec object.
@@ -706,7 +708,7 @@ pub struct MeasurementSeriesElement {
     pub index: u64,
 
     #[serde(rename = "value")]
-    pub value: Value,
+    pub value: tv::Value,
 
     #[serde(with = "rfc3339_format")]
     pub timestamp: DateTime<chrono_tz::Tz>,
@@ -716,7 +718,7 @@ pub struct MeasurementSeriesElement {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `diagnosis` spec object.
@@ -777,7 +779,7 @@ pub struct File {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "metadata")]
-    pub metadata: Option<Map<String, Value>>,
+    pub metadata: Option<BTreeMap<String, tv::Value>>,
 }
 
 /// Low-level model for the `extension` spec object.

--- a/tests/output/runner.rs
+++ b/tests/output/runner.rs
@@ -14,6 +14,7 @@ use assert_json_diff::{assert_json_eq, assert_json_include};
 use futures::future::BoxFuture;
 use futures::future::Future;
 use futures::FutureExt;
+use ocptv::output::OcptvError;
 use predicates::prelude::*;
 use serde_json::json;
 use tokio::sync::Mutex;
@@ -1351,6 +1352,109 @@ async fn test_config_builder_with_file() -> Result<()> {
     for (idx, entry) in content.lines().enumerate() {
         let value = serde_json::from_str::<serde_json::Value>(entry).unwrap();
         assert_json_include!(actual: value, expected: &expected[idx]);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_step_with_extension() -> Result<()> {
+    let expected = [
+        json_schema_version(),
+        json_run_default_start(),
+        json_step_default_start(),
+        json!({
+            "testStepArtifact": {
+                "testStepId": "step_0",
+                "extension": {
+                    "name": "extension",
+                    "content": {
+                        "@type": "TestExtension",
+                        "stringField": "string",
+                        "numberField": 42
+                    }
+                }
+            },
+            "sequenceNumber": 3,
+            "timestamp": DATETIME_FORMATTED
+        }),
+        json_step_complete(4),
+        json_run_pass(5),
+    ];
+
+    #[derive(serde::Serialize)]
+    struct Ext {
+        #[serde(rename = "@type")]
+        r#type: String,
+        #[serde(rename = "stringField")]
+        string_field: String,
+        #[serde(rename = "numberField")]
+        number_field: u32,
+    }
+
+    check_output_step(&expected, |step| {
+        async {
+            step.extension(
+                "extension",
+                Ext {
+                    r#type: "TestExtension".to_owned(),
+                    string_field: "string".to_owned(),
+                    number_field: 42,
+                },
+            )
+            .await?;
+
+            Ok(())
+        }
+        .boxed()
+    })
+    .await
+}
+
+#[tokio::test]
+async fn test_step_with_extension_which_fails() -> Result<()> {
+    #[derive(thiserror::Error, Debug, PartialEq)]
+    enum TestError {
+        #[error("test_error_fail")]
+        Fail,
+    }
+
+    fn fail_serialize<S>(_: &u32, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(serde::ser::Error::custom(TestError::Fail))
+    }
+
+    #[derive(serde::Serialize)]
+    struct Ext {
+        #[serde(serialize_with = "fail_serialize")]
+        i: u32,
+    }
+
+    let buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+    let dut = DutInfo::builder("dut_id").build();
+    let run = TestRun::builder("run_name", &dut, "1.0")
+        .config(
+            Config::builder()
+                .with_buffer_output(Arc::clone(&buffer))
+                .with_timestamp_provider(Box::new(FixedTsProvider {}))
+                .build(),
+        )
+        .build()
+        .start()
+        .await?;
+    let step = run.add_step("first step").start().await?;
+
+    let result = step.extension("extension", Ext { i: 0 }).await;
+
+    match result {
+        Err(OcptvError::Format(e)) => {
+            // `to_string` is the only way to check this error. `serde_json::Error` only
+            // implements source/cause for io errors, and this is a string
+            assert_eq!(e.to_string(), "test_error_fail");
+        }
+        _ => panic!("unexpected ocptv error type"),
     }
 
     Ok(())


### PR DESCRIPTION
- replace unnecessary serde_json::Maps with std::collections::*
  - this json impl was leaking into the spec definition
  - replace the maps with BTreeMap and the serde_json::Value with
  tv::Value (which is a type alias, but we control it)
- fix content on Extension spec
  - remove the hardcoded ExtensionContentType, replace with arbitrary json
  - this also add the crate api to emit extensions