### PR TITLE
fea/boxed scope

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -51,3 +51,15 @@ jobs:
         with:
           reporter: 'github-pr-check'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  hack:
+    runs-on: ubuntu-latest
+    name: ubuntu / stable / features
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: cargo hack
+        run: cargo hack --feature-powerset --no-dev-deps check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: cargo test --locked
         run: cargo test --locked --all-features
+
   os-check:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / stable
@@ -46,6 +47,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: cargo test
         run: cargo test --locked --all-features --all-targets
+
   coverage:
     runs-on: ubuntu-latest
     name: ubuntu / stable / coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,14 @@ repository = "https://github.com/opencomputeproject/ocp-diag-core-rust"
 license = "MIT"
 edition = "2021"
 
+[features]
+boxed-scopes = []
+
 [dependencies]
 async-trait = "0.1.83"
 chrono = "0.4.38"
 chrono-tz = "0.10.0"
+futures = "0.3.30"
 maplit = "1.0.2"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -70,7 +70,7 @@ impl TestStep {
     /// Builds a scope in the [`TestStep`] object, taking care of starting and
     /// ending it. View [`TestStep::start`] and [`TestStep::end`] methods.
     /// After the scope is constructed, additional objects may be added to it.
-    /// This is the preferred usage for the [`TestStep`], since it guarantees
+    /// This is the preferred usaggste for the [`TestStep`], since it guarantees
     /// all the messages are emitted between the start and end messages, the order
     /// is respected and no messages is lost.
     ///

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -8,6 +8,9 @@ use std::io;
 use std::sync::atomic::{self, Ordering};
 use std::sync::Arc;
 
+#[cfg(feature = "boxed-scopes")]
+use futures::future::BoxFuture;
+
 use crate::output as tv;
 use crate::spec::{self, TestStepArtifactImpl, TestStepStart};
 use tv::measure::MeasurementSeries;
@@ -64,43 +67,47 @@ impl TestStep {
         })
     }
 
-    // /// Builds a scope in the [`TestStep`] object, taking care of starting and
-    // /// ending it. View [`TestStep::start`] and [`TestStep::end`] methods.
-    // /// After the scope is constructed, additional objects may be added to it.
-    // /// This is the preferred usage for the [`TestStep`], since it guarantees
-    // /// all the messages are emitted between the start and end messages, the order
-    // /// is respected and no messages is lost.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```rust
-    // /// # tokio_test::block_on(async {
-    // /// # use ocptv::output::*;
-    // ///
-    // /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
-    // ///
-    // /// let step = run.add_step("first step")?;
-    // /// step.scope(|s| async {
-    // ///     s.add_log(
-    // ///         LogSeverity::Info,
-    // ///         "This is a log message with INFO severity",
-    // ///     ).await?;
-    // ///     Ok(TestStatus::Complete)
-    // /// }).await?;
-    // ///
-    // /// # Ok::<(), OcptvError>(())
-    // /// # });
-    // /// ```
-    // pub async fn scope<'a, F, R>(&'a self, func: F) -> Result<(), emitters::WriterError>
-    // where
-    //     R: Future<Output = Result<models::TestStatus, emitters::WriterError>>,
-    //     F: std::ops::FnOnce(&'a TestStep) -> R,
-    // {
-    //     self.start().await?;
-    //     let status = func(self).await?;
-    //     self.end(status).await?;
-    //     Ok(())
-    // }
+    /// Builds a scope in the [`TestStep`] object, taking care of starting and
+    /// ending it. View [`TestStep::start`] and [`TestStep::end`] methods.
+    /// After the scope is constructed, additional objects may be added to it.
+    /// This is the preferred usage for the [`TestStep`], since it guarantees
+    /// all the messages are emitted between the start and end messages, the order
+    /// is respected and no messages is lost.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use futures::FutureExt;
+    /// # use ocptv::output::*;
+    ///
+    /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
+    ///
+    /// let step = run.add_step("first step");
+    /// step.scope(|s| {
+    ///     async move {
+    ///         s.add_log(
+    ///             LogSeverity::Info,
+    ///             "This is a log message with INFO severity",
+    ///         ).await?;
+    ///         Ok(TestStatus::Complete)
+    ///     }.boxed()
+    /// }).await?;
+    ///
+    /// # Ok::<(), OcptvError>(())
+    /// # });
+    /// ```
+    #[cfg(feature = "boxed-scopes")]
+    pub async fn scope<F>(self, func: F) -> Result<(), tv::OcptvError>
+    where
+        F: FnOnce(&StartedTestStep) -> BoxFuture<'_, Result<tv::TestStatus, tv::OcptvError>>,
+    {
+        let step = self.start().await?;
+        let status = func(&step).await?;
+        step.end(status).await?;
+
+        Ok(())
+    }
 }
 
 pub struct StartedTestStep {

--- a/tests/output/runner.rs
+++ b/tests/output/runner.rs
@@ -1232,83 +1232,100 @@ async fn test_step_with_measurement_series_element_with_metadata_index_no() -> R
     .await
 }
 
-// #[tokio::test]
-// async fn test_step_with_measurement_series_scope() -> Result<()> {
-//     let expected = [
-//         json_schema_version(),
-//         json_run_default_start(),
-//         json_step_default_start(),
-//         json!({
-//             "testStepArtifact": {
-//                 "measurementSeriesStart": {
-//                     "measurementSeriesId": "series_0",
-//                     "name": "name"
-//                 }
-//             },
-//             "sequenceNumber": 3
-//         }),
-//         json!({
-//             "testStepArtifact": {
-//                 "measurementSeriesElement": {
-//                     "index": 0,
-//                     "measurementSeriesId": "series_0",
-//                     "value": 60
-//                 }
-//             },
-//             "sequenceNumber": 4
-//         }),
-//         json!({
-//             "testStepArtifact": {
-//                 "measurementSeriesElement": {
-//                     "index": 1,
-//                     "measurementSeriesId": "series_0",
-//                     "value": 70
-//                 }
-//             },
-//             "sequenceNumber": 5
-//         }),
-//         json!({
-//             "testStepArtifact": {
-//                 "measurementSeriesElement": {
-//                     "index": 2,
-//                     "measurementSeriesId": "series_0",
-//                     "value": 80
-//                 }
-//             },
-//             "sequenceNumber": 6
-//         }),
-//         json!({
-//             "testStepArtifact": {
-//                 "measurementSeriesEnd": {
-//                     "measurementSeriesId": "series_0",
-//                     "totalCount": 3
-//                 }
-//             },
-//             "sequenceNumber": 7
-//         }),
-//         json_step_complete(8),
-//         json_run_pass(9),
-//     ];
+#[cfg(feature = "boxed-scopes")]
+#[tokio::test]
+async fn test_step_with_measurement_series_scope() -> Result<()> {
+    let expected = [
+        json_schema_version(),
+        json_run_default_start(),
+        json_step_default_start(),
+        json!({
+            "testStepArtifact": {
+                "testStepId": "step_0",
+                "measurementSeriesStart": {
+                    "measurementSeriesId": "series_0",
+                    "name": "name"
+                }
+            },
+            "sequenceNumber": 3,
+            "timestamp": DATETIME_FORMATTED
+        }),
+        json!({
+            "testStepArtifact": {
+                "testStepId": "step_0",
+                "measurementSeriesElement": {
+                    "index": 0,
+                    "measurementSeriesId": "series_0",
+                    "value": 60,
+                    "timestamp": DATETIME_FORMATTED
+                }
+            },
+            "sequenceNumber": 4,
+            "timestamp": DATETIME_FORMATTED
+        }),
+        json!({
+            "testStepArtifact": {
+                "testStepId": "step_0",
+                "measurementSeriesElement": {
+                    "index": 1,
+                    "measurementSeriesId": "series_0",
+                    "value": 70,
+                    "timestamp": DATETIME_FORMATTED
+                }
+            },
+            "sequenceNumber": 5,
+            "timestamp": DATETIME_FORMATTED
+        }),
+        json!({
+            "testStepArtifact": {
+                "testStepId": "step_0",
+                "measurementSeriesElement": {
+                    "index": 2,
+                    "measurementSeriesId": "series_0",
+                    "value": 80,
+                    "timestamp": DATETIME_FORMATTED
+                }
+            },
+            "sequenceNumber": 6,
+            "timestamp": DATETIME_FORMATTED
+        }),
+        json!({
+            "testStepArtifact": {
+                "testStepId": "step_0",
+                "measurementSeriesEnd": {
+                    "measurementSeriesId": "series_0",
+                    "totalCount": 3
+                }
+            },
+            "sequenceNumber": 7,
+            "timestamp": DATETIME_FORMATTED
+        }),
+        json_step_complete(8),
+        json_run_pass(9),
+    ];
 
-//     check_output_step(&expected, |step| {
-//         async {
-//             let series = step.add_measurement_series("name");
-//             series
-//                 .scope(|s| async {
-//                     s.add_measurement(60.into()).await?;
-//                     s.add_measurement(70.into()).await?;
-//                     s.add_measurement(80.into()).await?;
+    check_output_step(&expected, |step| {
+        async {
+            let series = step.add_measurement_series("name");
+            series
+                .scope(|s| {
+                    async move {
+                        s.add_measurement(60.into()).await?;
+                        s.add_measurement(70.into()).await?;
+                        s.add_measurement(80.into()).await?;
 
-//                     Ok(())
-//                 })
-//                 .await?;
+                        Ok(())
+                    }
+                    .boxed()
+                })
+                .await?;
 
-//             Ok(())
-//         }
-//         .boxed()
-//     })
-//     .await
-// }
+            Ok(())
+        }
+        .boxed()
+    })
+    .await
+}
 
 // reasoning: the coverage(off) attribute is experimental in llvm-cov, so because we cannot
 // disable the coverage itself, only run this test when in coverage mode because assert_fs


### PR DESCRIPTION
- re-add `scope` methods but with boxed futures
  - guard this with a feature flag so users optin, since the need to use a
  boxed future is due to a rust syntax limitation (cannot capture
  lifetimes in async blocks RPIT), and this implies a stack allocation