### PR TITLE
Add Diagnosis API

### DIFF
--- a/src/output/diagnosis.rs
+++ b/src/output/diagnosis.rs
@@ -19,8 +19,7 @@ use tv::dut;
 /// ## Create a Diagnosis object with the `new` method
 ///
 /// ```
-/// use ocptv::output::Diagnosis;
-/// use ocptv::output::DiagnosisType;
+/// # use ocptv::output::*;
 ///
 /// let diagnosis = Diagnosis::new("verdict", DiagnosisType::Pass);
 /// ```
@@ -28,10 +27,7 @@ use tv::dut;
 /// ## Create a Diagnosis object with the `builder` method
 ///
 /// ```
-/// use ocptv::output::HardwareInfo;
-/// use ocptv::output::Diagnosis;
-/// use ocptv::output::DiagnosisType;
-/// use ocptv::output::Subcomponent;
+/// # use ocptv::output::*;
 ///
 /// let diagnosis = Diagnosis::builder("verdict", DiagnosisType::Pass)
 ///     .hardware_info(&HardwareInfo::builder("id", "name").build())
@@ -40,6 +36,7 @@ use tv::dut;
 ///     .source("file.rs", 1)
 ///     .build();
 /// ```
+#[derive(Default)]
 pub struct Diagnosis {
     verdict: String,
     diagnosis_type: spec::DiagnosisType,
@@ -55,19 +52,15 @@ impl Diagnosis {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::Diagnosis;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let diagnosis = Diagnosis::new("verdict", DiagnosisType::Pass);
     /// ```
     pub fn new(verdict: &str, diagnosis_type: spec::DiagnosisType) -> Self {
         Diagnosis {
-            verdict: verdict.to_string(),
+            verdict: verdict.to_owned(),
             diagnosis_type,
-            message: None,
-            hardware_info: None,
-            subcomponent: None,
-            source_location: None,
+            ..Default::default()
         }
     }
 
@@ -76,10 +69,7 @@ impl Diagnosis {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::HardwareInfo;
-    /// use ocptv::output::Diagnosis;
-    /// use ocptv::output::DiagnosisType;
-    /// use ocptv::output::Subcomponent;
+    /// # use ocptv::output::*;
     ///
     /// let Diagnosis = Diagnosis::builder("verdict", DiagnosisType::Pass)
     ///     .hardware_info(&HardwareInfo::builder("id", "name").build())
@@ -97,8 +87,7 @@ impl Diagnosis {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::Diagnosis;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let diagnosis = Diagnosis::new("verdict", DiagnosisType::Pass);
     /// let _ = diagnosis.to_artifact();
@@ -126,10 +115,7 @@ impl Diagnosis {
 /// # Examples
 ///
 /// ```
-/// use ocptv::output::HardwareInfo;
-/// use ocptv::output::Diagnosis;
-/// use ocptv::output::DiagnosisType;
-/// use ocptv::output::Subcomponent;
+/// # use ocptv::output::*;
 ///
 /// let builder = Diagnosis::builder("verdict", DiagnosisType::Pass)
 ///     .hardware_info(&HardwareInfo::builder("id", "name").build())
@@ -138,6 +124,7 @@ impl Diagnosis {
 ///     .source("file.rs", 1);
 /// let diagnosis = builder.build();
 /// ```
+#[derive(Default)]
 pub struct DiagnosisBuilder {
     verdict: String,
     diagnosis_type: spec::DiagnosisType,
@@ -153,19 +140,15 @@ impl DiagnosisBuilder {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::DiagnosisBuilder;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass);
     /// ```
     pub fn new(verdict: &str, diagnosis_type: spec::DiagnosisType) -> Self {
         DiagnosisBuilder {
-            verdict: verdict.to_string(),
+            verdict: verdict.to_owned(),
             diagnosis_type,
-            message: None,
-            hardware_info: None,
-            subcomponent: None,
-            source_location: None,
+            ..Default::default()
         }
     }
 
@@ -174,14 +157,13 @@ impl DiagnosisBuilder {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::DiagnosisBuilder;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
     ///     .message("message");
     /// ```
     pub fn message(mut self, message: &str) -> DiagnosisBuilder {
-        self.message = Some(message.to_string());
+        self.message = Some(message.to_owned());
         self
     }
 
@@ -190,9 +172,7 @@ impl DiagnosisBuilder {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::HardwareInfo;
-    /// use ocptv::output::DiagnosisBuilder;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
     ///     .hardware_info(&HardwareInfo::builder("id", "name").build());
@@ -207,9 +187,7 @@ impl DiagnosisBuilder {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::Subcomponent;
-    /// use ocptv::output::DiagnosisBuilder;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
     ///     .subcomponent(&Subcomponent::builder("name").build());
@@ -224,15 +202,14 @@ impl DiagnosisBuilder {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::DiagnosisBuilder;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
     ///     .source("file.rs", 1);
     /// ```
     pub fn source(mut self, file: &str, line: i32) -> DiagnosisBuilder {
         self.source_location = Some(spec::SourceLocation {
-            file: file.to_string(),
+            file: file.to_owned(),
             line,
         });
         self
@@ -243,8 +220,7 @@ impl DiagnosisBuilder {
     /// # Examples
     ///
     /// ```
-    /// use ocptv::output::DiagnosisBuilder;
-    /// use ocptv::output::DiagnosisType;
+    /// # use ocptv::output::*;
     ///
     /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass);
     /// let diagnosis = builder.build();
@@ -280,7 +256,7 @@ mod tests {
         assert_eq!(
             artifact,
             spec::Diagnosis {
-                verdict: verdict.to_string(),
+                verdict: verdict.to_owned(),
                 diagnosis_type,
                 message: None,
                 hardware_info_id: None,

--- a/src/output/diagnosis.rs
+++ b/src/output/diagnosis.rs
@@ -1,0 +1,327 @@
+// (c) Meta Platforms, Inc. and affiliates.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use crate::output as tv;
+use crate::spec;
+use tv::dut;
+
+/// This structure represents a Diagnosis message.
+/// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#diagnosis
+///
+/// Information about the source file and line number are not automatically added.
+/// Add them using the builder or the macros octptv_diagnosis_*
+///
+/// # Examples
+///
+/// ## Create a Diagnosis object with the `new` method
+///
+/// ```
+/// use ocptv::output::Diagnosis;
+/// use ocptv::output::DiagnosisType;
+///
+/// let diagnosis = Diagnosis::new("verdict", DiagnosisType::Pass);
+/// ```
+///
+/// ## Create a Diagnosis object with the `builder` method
+///
+/// ```
+/// use ocptv::output::HardwareInfo;
+/// use ocptv::output::Diagnosis;
+/// use ocptv::output::DiagnosisType;
+/// use ocptv::output::Subcomponent;
+///
+/// let diagnosis = Diagnosis::builder("verdict", DiagnosisType::Pass)
+///     .hardware_info(&HardwareInfo::builder("id", "name").build())
+///     .message("message")
+///     .subcomponent(&Subcomponent::builder("name").build())
+///     .source("file.rs", 1)
+///     .build();
+/// ```
+pub struct Diagnosis {
+    verdict: String,
+    diagnosis_type: spec::DiagnosisType,
+    message: Option<String>,
+    hardware_info: Option<tv::HardwareInfo>,
+    subcomponent: Option<tv::Subcomponent>,
+    source_location: Option<spec::SourceLocation>,
+}
+
+impl Diagnosis {
+    /// Builds a new Diagnosis object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::Diagnosis;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let diagnosis = Diagnosis::new("verdict", DiagnosisType::Pass);
+    /// ```
+    pub fn new(verdict: &str, diagnosis_type: spec::DiagnosisType) -> Self {
+        Diagnosis {
+            verdict: verdict.to_string(),
+            diagnosis_type,
+            message: None,
+            hardware_info: None,
+            subcomponent: None,
+            source_location: None,
+        }
+    }
+
+    /// Builds a new Diagnosis object using [`DiagnosisBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::HardwareInfo;
+    /// use ocptv::output::Diagnosis;
+    /// use ocptv::output::DiagnosisType;
+    /// use ocptv::output::Subcomponent;
+    ///
+    /// let Diagnosis = Diagnosis::builder("verdict", DiagnosisType::Pass)
+    ///     .hardware_info(&HardwareInfo::builder("id", "name").build())
+    ///     .message("message")
+    ///     .subcomponent(&Subcomponent::builder("name").build())
+    ///     .source("file.rs", 1)
+    ///     .build();
+    /// ```
+    pub fn builder(verdict: &str, diagnosis_type: spec::DiagnosisType) -> DiagnosisBuilder {
+        DiagnosisBuilder::new(verdict, diagnosis_type)
+    }
+
+    /// Creates an artifact from a Diagnosis object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::Diagnosis;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let diagnosis = Diagnosis::new("verdict", DiagnosisType::Pass);
+    /// let _ = diagnosis.to_artifact();
+    /// ```
+    pub fn to_artifact(&self) -> spec::Diagnosis {
+        spec::Diagnosis {
+            verdict: self.verdict.clone(),
+            diagnosis_type: self.diagnosis_type.clone(),
+            message: self.message.clone(),
+            hardware_info_id: self
+                .hardware_info
+                .as_ref()
+                .map(|hardware_info| hardware_info.id().to_owned()),
+            subcomponent: self
+                .subcomponent
+                .as_ref()
+                .map(|subcomponent| subcomponent.to_spec()),
+            source_location: self.source_location.clone(),
+        }
+    }
+}
+
+/// This structure builds a [`Diagnosis`] object.
+///
+/// # Examples
+///
+/// ```
+/// use ocptv::output::HardwareInfo;
+/// use ocptv::output::Diagnosis;
+/// use ocptv::output::DiagnosisType;
+/// use ocptv::output::Subcomponent;
+///
+/// let builder = Diagnosis::builder("verdict", DiagnosisType::Pass)
+///     .hardware_info(&HardwareInfo::builder("id", "name").build())
+///     .message("message")
+///     .subcomponent(&Subcomponent::builder("name").build())
+///     .source("file.rs", 1);
+/// let diagnosis = builder.build();
+/// ```
+pub struct DiagnosisBuilder {
+    verdict: String,
+    diagnosis_type: spec::DiagnosisType,
+    message: Option<String>,
+    hardware_info: Option<tv::HardwareInfo>,
+    subcomponent: Option<tv::Subcomponent>,
+    source_location: Option<spec::SourceLocation>,
+}
+
+impl DiagnosisBuilder {
+    /// Creates a new DiagnosisBuilder.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::DiagnosisBuilder;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass);
+    /// ```
+    pub fn new(verdict: &str, diagnosis_type: spec::DiagnosisType) -> Self {
+        DiagnosisBuilder {
+            verdict: verdict.to_string(),
+            diagnosis_type,
+            message: None,
+            hardware_info: None,
+            subcomponent: None,
+            source_location: None,
+        }
+    }
+
+    /// Add a message to a [`DiagnosisBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::DiagnosisBuilder;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
+    ///     .message("message");
+    /// ```
+    pub fn message(mut self, message: &str) -> DiagnosisBuilder {
+        self.message = Some(message.to_string());
+        self
+    }
+
+    /// Add a [`HardwareInfo`] to a [`DiagnosisBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::HardwareInfo;
+    /// use ocptv::output::DiagnosisBuilder;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
+    ///     .hardware_info(&HardwareInfo::builder("id", "name").build());
+    /// ```
+    pub fn hardware_info(mut self, hardware_info: &dut::HardwareInfo) -> DiagnosisBuilder {
+        self.hardware_info = Some(hardware_info.clone());
+        self
+    }
+
+    /// Add a [`Subcomponent`] to a [`DiagnosisBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::Subcomponent;
+    /// use ocptv::output::DiagnosisBuilder;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
+    ///     .subcomponent(&Subcomponent::builder("name").build());
+    /// ```
+    pub fn subcomponent(mut self, subcomponent: &dut::Subcomponent) -> DiagnosisBuilder {
+        self.subcomponent = Some(subcomponent.clone());
+        self
+    }
+
+    /// Add a [`SourceLocation`] to a [`DiagnosisBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::DiagnosisBuilder;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass)
+    ///     .source("file.rs", 1);
+    /// ```
+    pub fn source(mut self, file: &str, line: i32) -> DiagnosisBuilder {
+        self.source_location = Some(spec::SourceLocation {
+            file: file.to_string(),
+            line,
+        });
+        self
+    }
+
+    /// Builds a [`Diagnosis`] object from a [`DiagnosisBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ocptv::output::DiagnosisBuilder;
+    /// use ocptv::output::DiagnosisType;
+    ///
+    /// let builder = DiagnosisBuilder::new("verdict", DiagnosisType::Pass);
+    /// let diagnosis = builder.build();
+    /// ```
+    pub fn build(self) -> Diagnosis {
+        Diagnosis {
+            verdict: self.verdict,
+            diagnosis_type: self.diagnosis_type,
+            message: self.message,
+            hardware_info: self.hardware_info,
+            subcomponent: self.subcomponent,
+            source_location: self.source_location,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output as tv;
+    use crate::spec;
+    use anyhow::Result;
+    use tv::dut::*;
+
+    #[test]
+    fn test_diagnosis_as_test_step_descendant_to_artifact() -> Result<()> {
+        let verdict = "verdict".to_owned();
+        let diagnosis_type = spec::DiagnosisType::Pass;
+        let diagnosis = Diagnosis::new(&verdict, diagnosis_type.clone());
+
+        let artifact = diagnosis.to_artifact();
+
+        assert_eq!(
+            artifact,
+            spec::Diagnosis {
+                verdict: verdict.to_string(),
+                diagnosis_type,
+                message: None,
+                hardware_info_id: None,
+                subcomponent: None,
+                source_location: None,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_diagnosis_builder_as_test_step_descendant_to_artifact() -> Result<()> {
+        let verdict = "verdict".to_owned();
+        let diagnosis_type = spec::DiagnosisType::Pass;
+        let hardware_info = HardwareInfo::builder("id", "name").build();
+        let subcomponent = Subcomponent::builder("name").build();
+        let file = "file.rs".to_owned();
+        let line = 1;
+        let message = "message".to_owned();
+
+        let diagnosis = Diagnosis::builder(&verdict, diagnosis_type.clone())
+            .hardware_info(&hardware_info)
+            .message(&message)
+            .subcomponent(&subcomponent)
+            .source(&file, line)
+            .build();
+
+        let artifact = diagnosis.to_artifact();
+        assert_eq!(
+            artifact,
+            spec::Diagnosis {
+                verdict,
+                diagnosis_type,
+                hardware_info_id: Some(hardware_info.to_spec().id.clone()),
+                subcomponent: Some(subcomponent.to_spec()),
+                message: Some(message),
+                source_location: Some(spec::SourceLocation { file, line })
+            }
+        );
+
+        Ok(())
+    }
+}

--- a/src/output/macros.rs
+++ b/src/output/macros.rs
@@ -119,3 +119,55 @@ ocptv_log!(ocptv_log_info, Info);
 ocptv_log!(ocptv_log_warning, Warning);
 ocptv_log!(ocptv_log_error, Error);
 ocptv_log!(ocptv_log_fatal, Fatal);
+
+/// The following macros emit an artifact of type Diagnosis.
+/// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#diagnosis
+///
+/// Equivalent to the crate::output::StartedTestStep::diagnosis_with_details method.
+///
+/// They accept verdict as only parameter.
+/// Information about the source file and line number is automatically added.
+///
+/// There is one macro for each DiagnosisType variant: Pass, Fail, Unknown.
+///
+/// # Examples
+///
+/// ## DEBUG
+///
+/// ```rust
+/// # tokio_test::block_on(async {
+/// # use ocptv::output::*;
+///
+/// use ocptv::ocptv_diagnosis_pass;
+///
+/// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
+/// let step = run.add_step("step_name").start().await?;
+/// ocptv_diagnosis_pass!(step, "verdict");
+/// step.end(TestStatus::Complete).await?;
+/// run.end(TestStatus::Complete, TestResult::Pass).await?;
+///
+/// # Ok::<(), OcptvError>(())
+/// # });
+/// ```
+
+macro_rules! ocptv_diagnosis {
+    ($name:ident, $diagnosis_type:path) => {
+        #[macro_export]
+        macro_rules! $name {
+            ($artifact:expr, $verdict:expr) => {
+                $artifact.diagnosis_with_details(
+                    &$crate::output::Diagnosis::builder($verdict, $diagnosis_type)
+                        .source(file!(), line!() as i32)
+                        .build(),
+                )
+            };
+        }
+    };
+}
+
+ocptv_diagnosis!(ocptv_diagnosis_pass, ocptv::output::DiagnosisType::Pass);
+ocptv_diagnosis!(ocptv_diagnosis_fail, ocptv::output::DiagnosisType::Fail);
+ocptv_diagnosis!(
+    ocptv_diagnosis_unknown,
+    ocptv::output::DiagnosisType::Unknown
+);

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,6 +6,7 @@
 #![deny(warnings)]
 
 mod config;
+mod diagnosis;
 mod dut;
 mod emitter;
 mod error;
@@ -16,8 +17,11 @@ mod run;
 mod step;
 mod writer;
 
-pub use crate::spec::{LogSeverity, TestResult, TestStatus, ValidatorType, SPEC_VERSION};
+pub use crate::spec::{
+    DiagnosisType, LogSeverity, SourceLocation, TestResult, TestStatus, ValidatorType, SPEC_VERSION,
+};
 pub use config::{Config, ConfigBuilder, TimestampProvider};
+pub use diagnosis::{Diagnosis, DiagnosisBuilder};
 pub use dut::{
     DutInfo, DutInfoBuilder, HardwareInfo, HardwareInfoBuilder, PlatformInfo, PlatformInfoBuilder,
     SoftwareInfo, SoftwareInfoBuilder, Subcomponent, SubcomponentBuilder,

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -14,7 +14,7 @@ use futures::future::BoxFuture;
 use crate::output as tv;
 use crate::spec::{self, TestStepArtifactImpl, TestStepStart};
 use tv::measure::MeasurementSeries;
-use tv::{config, emitter, error, log, measure};
+use tv::{config, diagnosis, emitter, error, log, measure};
 
 use super::OcptvError;
 
@@ -529,6 +529,81 @@ impl StartedTestStep {
         start: measure::MeasurementSeriesStart,
     ) -> MeasurementSeries {
         MeasurementSeries::new_with_details(start, Arc::clone(&self.step.emitter))
+    }
+
+    /// Emits a Diagnosis message.
+    ///
+    /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#diagnosis
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use ocptv::output::*;
+    ///
+    /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
+    ///
+    /// let step = run.add_step("step_name").start().await?;
+    /// step.diagnosis("verdict", DiagnosisType::Pass).await?;
+    /// step.end(TestStatus::Complete).await?;
+    ///
+    /// # Ok::<(), OcptvError>(())
+    /// # });
+    /// ```
+    pub async fn diagnosis(
+        &self,
+        verdict: &str,
+        diagnosis_type: spec::DiagnosisType,
+    ) -> Result<(), tv::OcptvError> {
+        let diagnosis = diagnosis::Diagnosis::new(verdict, diagnosis_type);
+
+        self.step
+            .emitter
+            .emit(&TestStepArtifactImpl::Diagnosis(diagnosis.to_artifact()))
+            .await?;
+
+        Ok(())
+    }
+
+    /// Emits a Diagnosis message.
+    /// This method accepts a [`objects::Error`] object.
+    ///
+    /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#diagnosis
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use ocptv::output::*;
+    ///
+    /// let hwinfo = HardwareInfo::builder("id", "fan").build();
+    /// let run = TestRun::new("diagnostic_name", "my_dut", "1.0").start().await?;
+    /// let step = run.add_step("step_name").start().await?;
+    ///
+    /// let diagnosis = Diagnosis::builder("verdict", DiagnosisType::Pass)
+    ///     .hardware_info(&hwinfo)
+    ///     .message("message")
+    ///     .subcomponent(&Subcomponent::builder("name").build())
+    ///     .source("file.rs", 1)
+    ///     .build();
+    /// step.diagnosis_with_details(&diagnosis).await?;
+    /// step.end(TestStatus::Complete).await?;
+    ///
+    /// # Ok::<(), OcptvError>(())
+    /// # });
+    /// ```
+    pub async fn diagnosis_with_details(
+        &self,
+        diagnosis: &diagnosis::Diagnosis,
+    ) -> Result<(), tv::OcptvError> {
+        self.step
+            .emitter
+            .emit(&&spec::TestStepArtifactImpl::Diagnosis(
+                diagnosis.to_artifact(),
+            ))
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/src/output/step.rs
+++ b/src/output/step.rs
@@ -598,7 +598,7 @@ impl StartedTestStep {
     ) -> Result<(), tv::OcptvError> {
         self.step
             .emitter
-            .emit(&&spec::TestStepArtifactImpl::Diagnosis(
+            .emit(&spec::TestStepArtifactImpl::Diagnosis(
                 diagnosis.to_artifact(),
             ))
             .await?;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -727,11 +727,11 @@ pub struct Diagnosis {
     pub message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "validators")]
-    pub hardware_info: Option<HardwareInfo>,
+    #[serde(rename = "hardwareInfoId")]
+    pub hardware_info_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "subComponent")]
+    #[serde(rename = "subcomponent")]
     pub subcomponent: Option<Subcomponent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -85,9 +85,10 @@ pub enum SubcomponentType {
 /// ref: https://github.com/opencomputeproject/ocp-diag-core/tree/main/json_spec#diagnosistype
 /// schema url: https://github.com/opencomputeproject/ocp-diag-core/blob/main/json_spec/output/diagnosis.json
 /// schema ref: https://github.com/opencomputeproject/ocp-diag-core/diagnosis/$defs/type
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Clone, Default)]
 pub enum DiagnosisType {
     #[serde(rename = "PASS")]
+    #[default]
     Pass,
     #[serde(rename = "FAIL")]
     Fail,

--- a/tests/output/macros.rs
+++ b/tests/output/macros.rs
@@ -10,15 +10,15 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
-use ocptv::ocptv_diagnosis_fail;
-use ocptv::ocptv_diagnosis_pass;
-use ocptv::ocptv_diagnosis_unknown;
 use serde_json::json;
 use tokio::sync::Mutex;
 
 use ocptv::ocptv_error;
 use ocptv::output as tv;
-use ocptv::{ocptv_log_debug, ocptv_log_error, ocptv_log_fatal, ocptv_log_info, ocptv_log_warning};
+use ocptv::{
+    ocptv_diagnosis_fail, ocptv_diagnosis_pass, ocptv_diagnosis_unknown, ocptv_log_debug,
+    ocptv_log_error, ocptv_log_fatal, ocptv_log_info, ocptv_log_warning,
+};
 use tv::{Config, DutInfo, StartedTestRun, StartedTestStep, TestRun};
 
 async fn check_output<F, R, const N: usize>(
@@ -87,7 +87,7 @@ where
         Ok(())
     })
     .await?;
-    println!("----------------------------{}", actual);
+
     let source = actual
         .get("testStepArtifact")
         .ok_or(anyhow!("testRunArtifact key does not exist"))?

--- a/tests/output/macros.rs
+++ b/tests/output/macros.rs
@@ -10,6 +10,9 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
+use ocptv::ocptv_diagnosis_fail;
+use ocptv::ocptv_diagnosis_pass;
+use ocptv::ocptv_diagnosis_unknown;
 use serde_json::json;
 use tokio::sync::Mutex;
 
@@ -84,7 +87,7 @@ where
         Ok(())
     })
     .await?;
-
+    println!("----------------------------{}", actual);
     let source = actual
         .get("testStepArtifact")
         .ok_or(anyhow!("testRunArtifact key does not exist"))?
@@ -360,6 +363,63 @@ async fn test_ocptv_log_fatal_in_step() -> Result<()> {
 
     check_output_step(&expected, "log", |step| async move {
         ocptv_log_fatal!(step, "log message").await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn test_ocptv_diagnosis_pass_in_step() -> Result<()> {
+    let expected = json!({
+        "testStepArtifact": {
+            "diagnosis": {
+                    "verdict": "verdict",
+                    "type": "PASS",
+                }
+        },
+        "sequenceNumber": 3
+    });
+
+    check_output_step(&expected, "diagnosis", |step| async move {
+        ocptv_diagnosis_pass!(step, "verdict").await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn test_ocptv_diagnosis_fail_in_step() -> Result<()> {
+    let expected = json!({
+        "testStepArtifact": {
+            "diagnosis": {
+                    "verdict": "verdict",
+                    "type": "FAIL",
+                }
+        },
+        "sequenceNumber": 3
+    });
+
+    check_output_step(&expected, "diagnosis", |step| async move {
+        ocptv_diagnosis_fail!(step, "verdict").await?;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn test_ocptv_diagnosis_unknown_in_step() -> Result<()> {
+    let expected = json!({
+        "testStepArtifact": {
+            "diagnosis": {
+                    "verdict": "verdict",
+                    "type": "UNKNOWN",
+                }
+        },
+        "sequenceNumber": 3
+    });
+
+    check_output_step(&expected, "diagnosis", |step| async move {
+        ocptv_diagnosis_unknown!(step, "verdict").await?;
         Ok(())
     })
     .await


### PR DESCRIPTION
- Add diagnosis module with the Diagnosis API
- Add macros ocptv_diagnosis_pass, ocptv_diagnosis_fail, ocptv_diagnosis_unlnown
- Add Diagnosis to StartedTestStep API
- Fix Diagnosis in spec module to respect ocptv specs