### PR TITLE
Fix ownership for end method in StartedTestRun

### DIFF
--- a/src/output/run.rs
+++ b/src/output/run.rs
@@ -338,7 +338,7 @@ impl StartedTestRun {
     /// # });
     /// ```
     pub async fn end(
-        self,
+        &self,
         status: spec::TestStatus,
         result: spec::TestResult,
     ) -> Result<(), tv::OcptvError> {


### PR DESCRIPTION
Fix the end method that takes ownership of self without any needs